### PR TITLE
Allow custom time zones per organization

### DIFF
--- a/app/controllers/support/organizations_controller.rb
+++ b/app/controllers/support/organizations_controller.rb
@@ -27,7 +27,7 @@ class Support::OrganizationsController < SupportBaseController
   private
 
   def update_params
-    params.require(:organization).permit(:name)
+    params.require(:organization).permit(:name, :time_zone)
   end
 
   def check_organization

--- a/app/controllers/support_base_controller.rb
+++ b/app/controllers/support_base_controller.rb
@@ -1,6 +1,7 @@
 class SupportBaseController < ApplicationController
 
   before_filter :current_user, :authenticate_user!
+  around_filter :user_time_zone, :if => :current_user
 
   helper_method :current_section
 
@@ -12,6 +13,10 @@ class SupportBaseController < ApplicationController
 
   rescue_from CanCan::AccessDenied do |exception|
     redirect_to support_root_url, :alert => exception.message
+  end
+
+  def user_time_zone(&block)
+    Time.use_zone(current_user.organization.time_zone, &block)
   end
 
   private

--- a/app/views/support/organizations/organization.html.haml
+++ b/app/views/support/organizations/organization.html.haml
@@ -6,5 +6,8 @@
     .form-group
       %label Organization Name
       = f.text_field :name, class: "form-control"
+    .form-group
+      %label Time Zone
+      = f.time_zone_select :time_zone, nil, {include_blank: false}, {class: "form-control"}
 
     = submit_tag 'Save', class: 'btn btn-primary', data: { disable_with: 'Saving...' }

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,7 +14,7 @@ module Stronghold
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'London'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/db/migrate/20140805064643_add_timezone_to_organization.rb
+++ b/db/migrate/20140805064643_add_timezone_to_organization.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToOrganization < ActiveRecord::Migration
+  def change
+    add_column :organizations, :time_zone, :string, default: 'London', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140613150956) do
+ActiveRecord::Schema.define(version: 20140805064643) do
 
   create_table "invites", force: true do |t|
     t.string   "email"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20140613150956) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "time_zone",  default: "London", null: false
   end
 
   create_table "roles", force: true do |t|


### PR DESCRIPTION
This could also be on the user object if we feel orgs are likely to have staff in multiple timezones

![screen shot 2014-08-05 at 07 57 25](https://cloud.githubusercontent.com/assets/98526/3807821/c776f4c6-1c6d-11e4-94bc-146ca81b4f80.png)
