### PR TITLE
Faster tickets

### DIFF
--- a/app/assets/javascripts/support/filters.js.coffee
+++ b/app/assets/javascripts/support/filters.js.coffee
@@ -3,6 +3,17 @@ filters = angular.module("filters", [])
 filters.filter "momentDateTime", ->
   (time) ->
     return if !time
+    moment.lang 'en', {
+        'calendar' : {
+            'lastDay' : 'Do MMMM YYYY',
+            'sameDay' : 'h:mmA',
+            'nextDay' : 'Do MMMM YYYY',
+            'lastWeek' : 'Do MMMM YYYY',
+            'nextWeek' : 'Do MMMM YYYY',
+            'sameElse' : 'Do MMMM YYYY'
+       }
+    }
+    
     moment(time).calendar()
 
 filters.filter "lowerCaseStart", ->

--- a/app/assets/javascripts/support/tickets/ticket/factory.js.coffee
+++ b/app/assets/javascripts/support/tickets/ticket/factory.js.coffee
@@ -5,12 +5,6 @@ angularJS.factory "TicketFactory", ($http, TicketStatusFactory) ->
     successHandler = (response) ->
       if response.status is not 200
         return null
-      response.data.sort((a, b) ->
-        if a.time_updated > b.time_updated
-          -1
-        else
-          1
-      )
       response.data
 
     errorHandler = (response) ->

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -42,7 +42,7 @@ class Ticket
 
   def status_name
     return 'Open' unless @status
-    @status['status_type'] == 1 ? 'Closed' : 'Open'
+    @status == 1 ? 'Closed' : 'Open'
   end
 
   private


### PR DESCRIPTION
Speed up the time taken to show tickets.

Benchmarking shows this approach is around twice as fast when returning result sets of 50 tickets. If we reduce the result set size down to a limit of 15 tickets, the page loads between 3 and 4 times faster.

Introduction of on infinite-scroll or a "Load more" link will assist with retrieving older tickets in future.

Also fixed an ordering bug.
