### PR TITLE
Fog fix auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'unicorn', '~> 4.8'
 gem 'haml', '~> 4.0'
 gem 'cancancan', '~> 1.9'
 # gem 'fog', '~> 1.31', :require => "fog/openstack"
-gem 'fog', git: 'https://github.com/seanhandley/fog.git', branch: 'tenant_not_required'
+gem 'fog', git: 'https://github.com/seanhandley/fog.git', branch: 'fix_openstack_auth'
 gem 'gravatar_image_tag', '~> 1.2.0'
 gem 'js-routes', '~> 0.9.9'
 gem 'sidekiq', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,16 +20,18 @@ GIT
 
 GIT
   remote: https://github.com/seanhandley/fog.git
-  revision: e82b7b12e4204c0c9a7abec877e8c7b71780e945
-  branch: tenant_not_required
+  revision: e3cd481602d40c397ac350a76e0d5b2fdd463299
+  branch: fix_openstack_auth
   specs:
-    fog (1.31.0)
+    fog (1.36.0)
+      fog-aliyun (>= 0.1.0)
       fog-atmos
-      fog-aws (~> 0.0)
+      fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.30)
-      fog-ecloud
-      fog-google (>= 0.0.2)
+      fog-core (~> 1.32)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
       fog-json
       fog-local
       fog-powerdns (>= 0.1.1)
@@ -43,9 +45,10 @@ GIT
       fog-terremark
       fog-vmfusion
       fog-voxel
+      fog-vsphere (~> 0.2)
+      fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
 
 GEM
   remote: https://rubygems.org/
@@ -213,6 +216,11 @@ GEM
     flog (4.2.1)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.4)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
     fog-atmos (0.1.0)
       fog-core
       fog-xml
@@ -221,19 +229,22 @@ GEM
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.9.0)
+    fog-brightbox (0.10.1)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.34.0)
+    fog-core (1.35.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
-      mime-types
+    fog-dynect (0.0.2)
+      fog-core
+      fog-json
+      fog-xml
     fog-ecloud (0.3.0)
       fog-core
       fog-xml
-    fog-google (0.1.1)
+    fog-google (0.1.0)
       fog-core
       fog-json
       fog-xml
@@ -277,6 +288,12 @@ GEM
       fission
       fog-core
     fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-vsphere (0.3.0)
+      fog-core
+      rbvmomi (~> 1.8)
+    fog-xenserver (0.2.2)
       fog-core
       fog-xml
     fog-xml (0.1.2)
@@ -344,7 +361,7 @@ GEM
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.8.2)
     minitest-capybara (0.7.2)
       capybara (~> 2.2)
@@ -372,8 +389,8 @@ GEM
     net-ssh (2.8.0)
     netrc (0.11.0)
     newrelic_rpm (3.9.9.275)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     paranoia (2.1.4)
       activerecord (~> 4.0)
     parser (2.2.2.6)
@@ -451,6 +468,10 @@ GEM
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)
       trollop (>= 1.16.2)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
     rdoc (4.2.0)
     recaptcha (0.4.0)
     redcarpet (3.3.2)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,12 +113,12 @@ class User < ActiveRecord::Base
     cache = Rails.cache
     cache.delete("ec2_credentials_#{id}") unless cache.fetch("ec2_credentials_#{id}")
     cache.fetch("ec2_credentials_#{id}", expires_in: 30.days) do
-      OpenStackConnection.identity.list_ec2_credentials(uuid).body['credentials'].first
+      OpenStackConnection.identity.list_ec2_credentials(user_id: uuid).body['credentials'].first
     end
   end
 
   def refresh_ec2_credentials!   
-    OpenStackConnection.identity.list_ec2_credentials(uuid).body['credentials'].each do |credential|
+    OpenStackConnection.identity.list_ec2_credentials(user_id: uuid).body['credentials'].each do |credential|
       OpenStackConnection.identity.delete_ec2_credential(uuid, credential['access'])
     end
     OpenStackConnection.identity.create_ec2_credential(uuid, organization.primary_tenant.uuid)

--- a/config/initializers/openstack.rb
+++ b/config/initializers/openstack.rb
@@ -5,7 +5,8 @@ OPENSTACK_ARGS = {
   :openstack_auth_url => settings['auth_url'],
   :openstack_username => ENV["OPENSTACK_USERNAME"],
   :openstack_api_key  => ENV["OPENSTACK_PASSWORD"],
-  :openstack_tenant   => ENV["OPENSTACK_TENANT"]
+  :openstack_tenant   => ENV["OPENSTACK_TENANT"],
+  :openstack_identity_prefix => settings['identity_prefix']
 }
 
 Excon.defaults[:connect_timeout] = 10

--- a/config/openstack.yml
+++ b/config/openstack.yml
@@ -1,5 +1,6 @@
 default: &default
   auth_url: "http://devstack.datacentred.io:5000/v2.0/tokens"
+  identity_prefix: "/v2.0"
 
 development:
   <<: *default

--- a/lib/tasks/ceph_sync.rake
+++ b/lib/tasks/ceph_sync.rake
@@ -13,7 +13,7 @@ namespace :stronghold do
         end
       end
       organization.users.each do |user|
-        credentials = OpenStackConnection.identity.list_ec2_credentials(user.uuid).body['credentials']
+        credentials = OpenStackConnection.identity.list_ec2_credentials(user_id: user.uuid).body['credentials']
         tenants_with_creds = credentials.collect{|c| c['tenant_id']}
         organization.tenants.each do |tenant|
           unless tenants_with_creds.include?(tenant.uuid)


### PR DESCRIPTION
Use our Fog fork to handle Keystone v2 and v3 together.

If OpenStack exposes multiple versions of Keystone, the client needs to decide whether to prepend v2.0 or v3 inside the API URL path. This is because the endpoint in Keystone's DB needs to have the version stripped out, otherwise the service catalog would force the client to use either v2 or v3.

Leaving the decision in the hands of the client is the best way around this.
