### PR TITLE
Use the v2.0 prefix on prod now we serve both Keystone versions.

### DIFF
--- a/config/openstack.yml
+++ b/config/openstack.yml
@@ -17,3 +17,4 @@ staging:
 production:
   <<: *default
   auth_url: "https://compute.datacentred.io:5000/v2.0/tokens"
+  identity_prefix: "/v2.0"


### PR DESCRIPTION
Use the v2.0 prefix on prod now we serve both Keystone versions.
