### PR TITLE
Force all access to /admin to happen via admin-my subdomain.

### DIFF
--- a/app/views/shared/_support_nav.html.haml
+++ b/app/views/shared/_support_nav.html.haml
@@ -10,7 +10,7 @@
         My Profile
     - if current_user.staff?
       %li
-        %a{:href => admin_root_path}
+        %a{:href => admin_root_url(host: 'https://admin-my.datacentred.io')}
           %i.fa.fa-shield
           = 'Admin'
     - if current_user.power_user?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
 
   require 'sidekiq/web'
-  require_relative "../lib/constraints/staff_constraint"
-  mount Sidekiq::Web => '/queue', :constraints => StaffConstraint.new
+  require_relative "../lib/constraints/client_cert_constraint"
+
+  mount Sidekiq::Web => '/queue', :constraints => ClientCertConstraint.new
 
   mount Starburst::Engine => "/starburst"
 
@@ -35,8 +36,7 @@ Rails.application.routes.draw do
     post '/contacts/find', :controller => 'contacts', :action => 'find'
   end
 
-  # TODO: Add subnets to lib/admin_constraint.rb
-  #constraints AdminConstraint.new do
+  constraints ClientCertConstraint.new do
     namespace :admin do
       root :to => 'dashboard#index'
       resources :customers, only: [:new, :create]
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
       end
       resources :pending_invoices, only: [:index, :update, :destroy]
     end
-  #end
+  end
 
   resources :sessions, only: [:create, :destroy, :new, :index]
   resources :resets, only: [:create, :new, :show, :update]

--- a/lib/constraints/client_cert_constraint.rb
+++ b/lib/constraints/client_cert_constraint.rb
@@ -1,0 +1,9 @@
+require_relative "./staff_constraint"
+
+class ClientCertConstraint
+  def matches?(request)
+    return true  unless Rails.env.production?
+    return false unless request.host == 'admin-my.datacentred.io'
+    return false unless StaffConstraint.new.matches?(request)
+  end
+end


### PR DESCRIPTION
Nginx will handle x509 cert auth for the `admin-my.datacentred.io` subdomain. This should keep anyone without a valid cert from accessing Stronghold's admin functions.
