### PR TITLE
Automatically backfill usage in 30 min segments

### DIFF
--- a/app/jobs/usage_job.rb
+++ b/app/jobs/usage_job.rb
@@ -1,11 +1,20 @@
 class UsageJob < ActiveJob::Base
   queue_as :default
 
-  def perform(mins=nil)
-    Billing.sync!(mins) unless already_running?
+  def perform
+    return if already_running?
+    while(mins_since_sync > Billing::SYNC_INTERVAL_MINUTES) do
+      Billing.sync!(Billing::SYNC_INTERVAL_MINUTES)
+    end
+    Billing.sync!
   end
 
   private
+
+  def mins_since_sync
+    last_sync = Billing::Sync.completed.last
+    (Time.now - last_sync.period_to) * 60.0
+  end
 
   def already_running?
     usage_job_count = Sidekiq::Workers.new.select do |process_id, thread_id, work|

--- a/clock.rb
+++ b/clock.rb
@@ -4,7 +4,7 @@ require File.expand_path('config/environment', File.dirname(__FILE__))
 include Clockwork
 
 if Rails.env.production? || Rails.env.staging?
-  every(30.minutes, 'usage_sync') do
+  every(Billing::SYNC_INTERVAL_MINUTES.minutes, 'usage_sync') do
     UsageJob.perform_later
   end
 

--- a/lib/billing.rb
+++ b/lib/billing.rb
@@ -5,6 +5,7 @@ module Billing
   require_relative 'billing/volumes'
 
   SECONDS_TO_HOURS = 3600.0
+  SYNC_INTERVAL_MINUTES = 30
 
   def self.sync!(to=nil)
     last_sync = Billing::Sync.completed.last


### PR DESCRIPTION
Self-healing usage syncs a-go-go. Recovers from Ceilometer downtimes automatically.
