### PR TITLE
Fix users template

### DIFF
--- a/app/assets/stylesheets/components/admin/customers.scss
+++ b/app/assets/stylesheets/components/admin/customers.scss
@@ -52,6 +52,11 @@ div.admin-customer-section .panel-body ul li {
   padding: 10px 10px 10px 10px;
 }
 
+div.admin-customer-section .panel#users-panel {
+  max-height: 500px;
+  overflow: auto;
+}
+
 div.admin-customer-section div.row.info-list ul li {
   list-style-type: none;
 }

--- a/app/views/admin/customers/_users.html.haml
+++ b/app/views/admin/customers/_users.html.haml
@@ -1,17 +1,13 @@
 .table-responsive
   %table.table.table-hover
-    %thead
-      %th Name
-      %th
-      %th Email
-
     %tbody
       - if @users.any?
         - @users.each do |user|
           %tr
-            %td= user[:first_name]
-            %td= user[:last_name]
-            %td= user[:email]
+            %td= mail_to user[:email]
+            %td
+              = user[:first_name] != user[:email] ? user[:first_name] : ''
+              = user[:last_name] != user[:email] ? user[:last_name] : ''
       - else
         %tr
           %td

--- a/app/views/admin/customers/show.html.haml
+++ b/app/views/admin/customers/show.html.haml
@@ -39,7 +39,7 @@
           = render partial: "support/audits/audits", locals: {audits: @audits}
 
     .col-md-4
-      %div{class: ["panel", @organization.self_service? ? "panel-info" : "panel-danger"].join(" ")}
+      %div{class: ["panel", @organization.self_service? ? "panel-info" : "panel-warning"].join(" ")}
         .panel-heading
           %div{style: "display: flex; justify-content: space-between;"}
             %div
@@ -62,7 +62,7 @@
           = render partial: 'admin/customers/usage'
           = link_to 'See Usage Data', admin_usage_path(@organization), class: 'link-usage-data'
 
-      .panel.panel-info
+      .panel.panel-info#users-panel
         .panel-heading
           %i.fa.fa-user
           Users


### PR DESCRIPTION
- [x] Show users more sensibly - many have no name but just an email address.
- [x] Some accounts have loads of users (see Gigaspaces). Should this list just keep extending down the page?
- [x] User email address should mail_to link to the address for easy contact.
- [x] User names have a big space between first and surname
- [x] Invoiced/Trial accounts shouldn't be red - it makes it look like there's a problem. Choose better colours.
