### PR TITLE
Fix nameError

### DIFF
--- a/lib/billing/instances.rb
+++ b/lib/billing/instances.rb
@@ -264,7 +264,6 @@ module Billing
                                         flavor_id: meta_data["instance_flavor_id"]
         end
       end
-      instance.complete!
     end
 
   end


### PR DESCRIPTION
Delete line in instances.rb causing nameError.

![screenshot 2016-07-27 11 10 31](https://cloud.githubusercontent.com/assets/12121779/17172083/637fcc42-53eb-11e6-8c46-c7141df0ce8d.png)
