### PR TITLE
Faster terminal

### DIFF
--- a/app/controllers/support/terminal_controller.rb
+++ b/app/controllers/support/terminal_controller.rb
@@ -28,7 +28,7 @@ class Support::TerminalController < SupportBaseController
 
   def fetch_response
     begin
-      Terminal.new(credentials).run_command run_command_params[:command]
+      Terminal.fetch(credentials).run_command run_command_params[:command]
     rescue StandardError => e
       [false, e.message]
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,7 @@ module Stronghold
     # Default to Stripe Test
     config.stripe.publishable_key = "pk_test_7MJ5VPJPLNmTgHLC21kuoYCh"
 
+    config.terminals = {}
+
   end
 end


### PR DESCRIPTION
Commands can take up to five seconds to execute.

This isn't Docker's fault (containers spin up in half a second or so) - the issue is re-authenticating the openstack client every time it's run (even if it uses an auth token). Also, the client can't cache anything if we execute it standalone for each command.

The solution is a long running container with openstack client running in TTY. Sub-command execution involves injecting the subcommand on STDIN and then running a thread to stream the responses back out.

We'll need web sockets or similar so the JavaScript can receive the updates. We'll also need to think about managing the number of running containers carefully.

https://github.com/websocket-rails/websocket-rails
