### PR TITLE
Revoke user tokens when they log out.

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,6 +52,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    RevokeProjectTokensJob.perform_later(current_user)
     reset_session
     respond_to do |wants|
       wants.html { redirect_to sign_in_path, :notice => "You have been signed out." }

--- a/app/jobs/revoke_project_tokens_job.rb
+++ b/app/jobs/revoke_project_tokens_job.rb
@@ -1,0 +1,7 @@
+class RevokeProjectTokensJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(user)
+    Terminal::OpenStackCommand.revoke_project_tokens(user)
+  end
+end

--- a/lib/terminal/open_stack_command.rb
+++ b/lib/terminal/open_stack_command.rb
@@ -150,6 +150,18 @@ class Terminal
       end
     end
 
+    def self.revoke_project_tokens(user)
+      key = "os_tokens_user_#{user.id}"
+      Rails.cache.fetch(key)&.values.each do |token|
+        begin
+          OpenStackConnection.identity.token_revoke(token)
+        rescue Fog::Errors::Error => e
+          Honeybadger.notify(e)
+        end
+      end
+      Rails.cache.delete(key)
+    end
+
     def compute_endpoint
       "#{OpenStackCommand.compute_endpoint_base}/#{project_uuid}"
     end


### PR DESCRIPTION
A user's keystone tokens shouldn't be valid after they sign out.
