### PR TITLE
It's too slow to reindex *every* time.

### DIFF
--- a/app/models/billing/instance_state.rb
+++ b/app/models/billing/instance_state.rb
@@ -55,7 +55,6 @@ module Billing
     private
 
     def touch_instance
-      billing_instance.reindex_states
       billing_instance.update_attributes(terminated_at: recorded_at) if state == 'deleted'
       if billing_instance.started_at.nil?
         billing_instance.update_attributes(started_at: recorded_at)

--- a/lib/billing/instances.rb
+++ b/lib/billing/instances.rb
@@ -108,6 +108,7 @@ module Billing
                                         flavor_id: meta_data["instance_flavor_id"]
         end
       end
+      billing_instance.reindex_states
     end
 
   end

--- a/test/unit/models/billing/instance/instance_history_test.rb
+++ b/test/unit/models/billing/instance/instance_history_test.rb
@@ -14,6 +14,7 @@ class TestInstanceHistory < CleanTest
     @instance.instance_states.create(@defaults.merge(recorded_at: @start_time - 2.days, state: 'active', instance_flavor: @large_flavor))
     @instance.instance_states.create(@defaults.merge(recorded_at: @start_time - 24.hours, state: 'stopped', instance_flavor: @large_flavor))
     @instance.instance_states.create(@defaults.merge(recorded_at: @start_time - 22.hours, state: 'active', instance_flavor: @large_flavor))
+    @instance.reindex_states
   end
 
   def test_instance_seconds

--- a/test/unit/models/billing/instance_state/instance_states_chaining_test.rb
+++ b/test/unit/models/billing/instance_state/instance_states_chaining_test.rb
@@ -8,6 +8,7 @@ class TestInstanceStatesChaining < CleanTest
     @instance.instance_states.create(@defaults)
     @instance.instance_states.create(@defaults.merge(recorded_at: Time.now - 4.minutes))
     @instance.instance_states.create(@defaults.merge(recorded_at: Time.now - 2.minutes))
+    @instance.reindex_states
     @state_1, @state_2, @state_3 = @instance.instance_states
   end
 
@@ -39,6 +40,7 @@ class TestInstanceStatesChaining < CleanTest
       refute s.previous_state
     end
     @state_4 = @instance.instance_states.create(@defaults.merge(recorded_at: Time.now - 1.minutes))
+    @instance.reindex_states
 
     [@state_1, @state_2, @state_3, @state_4].each(&:reload)
 


### PR DESCRIPTION
This is exponential complexity as the number of states per instance increases. Makes more sense to reindex when needed, rather than every time a new event is added.
