### PR TITLE
Determine appropriate team for support tickets

### DIFF
--- a/app/controllers/support/api/tickets_controller.rb
+++ b/app/controllers/support/api/tickets_controller.rb
@@ -8,7 +8,6 @@ class Support::Api::TicketsController < SupportBaseController#
 
   def index
     @tickets = decorated_tickets
-    
     respond_to do |format|
       format.json {
         render :json => @tickets

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -5,7 +5,6 @@ class Ticket
                 :comments,  :status, :name, :email, :department, :priority,
                 :more_info, :visitor_names, :nature_of_visit,
                 :date_of_visit, :time_of_visit, :as_hash
->>>>>>> use a new department for colour support.
 
   validates :title,       length: {minimum: 1, maximum: 200}, allow_blank: false, unless: :access_request?
   validates :description, length: {minimum: 1}, allow_blank: false, unless: :access_request?

--- a/lib/ticket_adapter.rb
+++ b/lib/ticket_adapter.rb
@@ -95,14 +95,9 @@ class TicketAdapter
                            'custom[date_of_visit]'   => ticket.date_of_visit,
                            'custom[time_of_visit]'   => ticket.time_of_visit})
       when "Support"
-<<<<<<< 0de9e3d8c0ba828dca230421bf19ba0d723a6614
         properties.merge!({'custom[more_info]' => ticket.more_info})
-        if organization.colo?
-          properties.merge!({:department => "Colo Support"})
-=======
         if Authorization.current_user.organization.colo?
           params.merge!(:department => "Colo Support")
->>>>>>> Merge to the properties hash.
         end
       end
       new_ticket = SIRPORTLY.create_ticket(properties)


### PR DESCRIPTION
[APP-478](https://datacentred.atlassian.net/browse/APP-478)

When a customer raises a support ticket, it's assigned to the DevOps team and in the case of an emergency the relevant person on-call is subsequently paged.
There needs to be a way for colo customers to be able to raise a support ticket but which is immediately assigned to the SiteOps team and escalated where appropriate.
