### PR TITLE
Stop the Usage Job doubling up.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ gem 'statesman', '~> 2.0'
 gem 'parallel'
 gem 'docker-api', '~> 1.31'
 gem 'gibberish', '~> 2.1'
-gem 'sidekiq-unique-jobs', '~> 4.0'
 
 group :test, :acceptance do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,9 +423,6 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
-    sidekiq-unique-jobs (4.0.18)
-      sidekiq (>= 2.6)
-      thor
     simplecov (0.9.1)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -617,7 +614,6 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   select2-rails (~> 3.5.9.1)
   sidekiq (~> 4.0)
-  sidekiq-unique-jobs (~> 4.0)
   simplecov
   sinatra (~> 1.4)
   sirportly (~> 1.3)

--- a/app/jobs/usage_job.rb
+++ b/app/jobs/usage_job.rb
@@ -1,9 +1,14 @@
+$usage_job_mutex = Mutex.new
+
 class UsageJob < ActiveJob::Base
   queue_as :default
 
-  def perform(args=nil)
-    while(mins_since_sync > Billing::SYNC_INTERVAL_MINUTES) do
-      Billing.sync!(Billing::SYNC_INTERVAL_MINUTES)
+  def perform
+    return if $usage_job_mutex.locked?
+    $usage_job_mutex.synchronize do
+      while(mins_since_sync > Billing::SYNC_INTERVAL_MINUTES) do
+        Billing.sync!(Billing::SYNC_INTERVAL_MINUTES)
+      end
     end
   end
 

--- a/clock.rb
+++ b/clock.rb
@@ -9,7 +9,7 @@ if Rails.env.production? || Rails.env.staging?
   end
 
   every(90.minutes, 'usage_sync') do
-    UsageJob.perform_later(nil)
+    UsageJob.perform_later
   end
 
   every(20.minutes, 'activation_reminder') do

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,3 @@
-Sidekiq.default_worker_options = {
-  unique: :until_and_while_executing,
-  unique_args: ->(args) { [ args.first.except('job_id') ]},
-  unique_job_expiration: 600
-}
-
 Sidekiq.configure_server do |config|
   config.error_handlers << Proc.new {|ex,_| Honeybadger.notify(ex) }
   config.redis = { :namespace => 'stronghold' }


### PR DESCRIPTION
Yeah, I know. It's not pretty but the `sidekiq_uniq_jobs` gem just isn't working.