### PR TITLE
Add an autocomplete feature to the Billing and Technical contacts fields.

### DIFF
--- a/app/views/admin/customers/edit.html.haml
+++ b/app/views/admin/customers/edit.html.haml
@@ -10,10 +10,16 @@
     = f.text_field :name, class: 'form-control'
   .form-group
     %label Billing Contact
-    = f.text_field :billing_contact, class: "form-control autocomplete-field", 'data-autocomplete-options' => current_organization.users.collect(&:email).to_json
+    = f.text_field :billing_contact, list: "billing-emails2", class: 'form-control'
+    %datalist{id: "billing-emails2"}
+      - @organization.users.each do |user|
+        %option{:value => user.email}
   .form-group
     %label Technical Contact
-    = f.text_field :technical_contact, class: "form-control autocomplete-field", 'data-autocomplete-options' => current_organization.users.collect(&:email).to_json
+    = f.text_field :technical_contact, list: "technical-emails2", class: 'form-control'
+    %datalist{id: "technical-emails2"}
+      - @organization.users.each do |user|
+        %option{:value => user.email}
   .form-group
     %label Stripe Customer ID
     = f.text_field :stripe_customer_id, class: 'form-control'

--- a/app/views/support/organizations/organization.html.haml
+++ b/app/views/support/organizations/organization.html.haml
@@ -25,10 +25,16 @@
         = f.time_zone_select :time_zone, nil, {include_blank: false}, {class: "form-control"}
       .form-group
         %label Billing Contact
-        = f.text_field :billing_contact, class: "form-control autocomplete-field", 'data-autocomplete-options' => current_organization.users.collect(&:email).to_json
+        = f.text_field :billing_contact, list: "billing-emails", class: 'form-control'
+        %datalist{id: "billing-emails"}
+          - @organization.users.each do |user|
+            %option{:value => user.email}
       .form-group
         %label Technical Contact
-        = f.text_field :technical_contact, class: "form-control autocomplete-field", 'data-autocomplete-options' => current_organization.users.collect(&:email).to_json
+        = f.text_field :technical_contact, list: "technical-emails", class: 'form-control'
+        %datalist{id: "technical-emails"}
+          - @organization.users.each do |user|
+            %option{:value => user.email}
     .col-md-6
       %h3 Billing Address
       .form-group


### PR DESCRIPTION
Billing and Technical contacts should have an autocomplete field in both Support and Admin Section.

![screen shot 2016-12-13 at 16 32 28](https://cloud.githubusercontent.com/assets/12121779/21149085/357fabbc-c152-11e6-8ad3-fdd1cd1fea7e.png)

![screen shot 2016-12-13 at 16 32 57](https://cloud.githubusercontent.com/assets/12121779/21149089/3b31bc76-c152-11e6-997e-da3f255c1e17.png)

