### PR TITLE
Try to stop the queue getting clogged up.

### DIFF
--- a/app/jobs/graph_cache_warmer_job.rb
+++ b/app/jobs/graph_cache_warmer_job.rb
@@ -1,7 +1,0 @@
-class GraphCacheWarmerJob < ActiveJob::Base
-  queue_as :default
-
-  def perform
-    LiveCloudResources.refresh_caches
-  end
-end

--- a/app/jobs/live_cloud_resources_job.rb
+++ b/app/jobs/live_cloud_resources_job.rb
@@ -1,0 +1,12 @@
+$live_cloud_resources_job_mutex = Mutex.new
+
+class LiveCloudResourcesJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    return if $live_cloud_resources_job_mutex.locked?
+    $live_cloud_resources_job_mutex.synchronize do
+      LiveCloudResources.refresh_caches
+    end
+  end
+end

--- a/app/jobs/soulmate_job.rb
+++ b/app/jobs/soulmate_job.rb
@@ -1,9 +1,14 @@
 require_relative '../../lib/soulmate_loader'
 
+$soulmate_job_mutex = Mutex.new
+
 class SoulmateJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    SoulmateLoader.load_search_terms
+    return if $soulmate_job_mutex.locked?
+    $soulmate_job_mutex.synchronize do
+      SoulmateLoader.load_search_terms
+    end
   end
 end

--- a/app/jobs/usage_cache_refresh_job.rb
+++ b/app/jobs/usage_cache_refresh_job.rb
@@ -7,7 +7,7 @@ class UsageCacheRefreshJob < ActiveJob::Base
       return
     end
     
-    dispersal_time = 600
+    dispersal_time = 2 * 360
     spacing = dispersal_time / Organization.active.count
     organizations.each_with_index do |organization, i|
       x = (spacing * i * 1.1) + 5


### PR DESCRIPTION
Long-running jobs are clogging up the queue preventing other jobs from being processed. Fixing this by:

* [x] Making recurring jobs unique via mutexes
* [x] Reducing frequency of usage cache refresh jobs
* [x] Increasing dispersal time of usage cache refresh jobs

Hopefully this will lead to a more peaceful and harmonious queue 🌈 