### PR TITLE
Correctly raise final invoice.

### DIFF
--- a/app/jobs/raise_final_invoice_job.rb
+++ b/app/jobs/raise_final_invoice_job.rb
@@ -1,0 +1,10 @@
+class RaiseFinalInvoiceJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(organization)
+    killed_at = organization.transitions.where(to_state: 'closed').first
+    ud = UsageDecorator.new(organization, killed_at.year, killed_at.month)
+    ud.usage_data(force: true)
+    BillingRunOrgJob.perform_later(organization, killed_at.year, killed_at.month)
+  end
+end

--- a/app/models/organization_state_machine.rb
+++ b/app/models/organization_state_machine.rb
@@ -87,7 +87,7 @@ class OrganizationStateMachine
         project.destroy rescue project.delete
       end
       organization.update_column(:disabled, true)
-      BillingRunOrgJob.perform_later(organization, Date.today.year, Date.today.month)
+      RaiseFinalInvoiceJob.set(wait: 4.hours).perform_later(organization)
     end
   end
 


### PR DESCRIPTION
Their usage and cache need bringing up to date before we raise.