### PR TITLE
Stop usage jobs trampling cache refreshes.

### DIFF
--- a/app/jobs/usage_job.rb
+++ b/app/jobs/usage_job.rb
@@ -6,9 +6,12 @@ class UsageJob < ActiveJob::Base
   def perform
     return if $usage_job_mutex.locked?
     $usage_job_mutex.synchronize do
+      count = 0
       while(mins_since_sync > Billing::SYNC_INTERVAL_MINUTES) do
         Billing.sync!(Billing::SYNC_INTERVAL_MINUTES)
+        count += 1
       end
+      UsageCacheRefreshJob.perform_later if count > 0
     end
   end
 

--- a/clock.rb
+++ b/clock.rb
@@ -9,7 +9,7 @@ if Rails.env.production? || Rails.env.staging?
     LiveCloudResourcesJob.perform_later
   end
 
-  every(40.minutes, 'usage_sync') do
+  every(3.hours, 'usage_sync') do
     UsageJob.perform_later
   end
 
@@ -19,10 +19,6 @@ if Rails.env.production? || Rails.env.staging?
 
   every(1.day, 'reaper', :at => '03:00') do
     ReaperJob.perform_later
-  end
-
-  every(4.hours, 'usage_cache_refresh') do
-    UsageCacheRefreshJob.perform_later
   end
 
   every(5.minutes, 'status_io_cache_warm') do


### PR DESCRIPTION
If we kick cache refreshes off when usage jobs are finished, life is good.