### PR TITLE
Fix another capacity used bug.

### DIFF
--- a/app/decorators/organization_graph_decorator.rb
+++ b/app/decorators/organization_graph_decorator.rb
@@ -58,7 +58,7 @@ class OrganizationGraphDecorator < ApplicationDecorator
 
   def quota_used
     return 0 if model.projects.none?
-    model.projects.map{|proj| proj.total_used_as_percent}.sum / model.projects.size
+    model.projects.map(&:total_used_as_percent).sum / model.projects.count
   end
 
   def instance_count


### PR DESCRIPTION
![screen shot 2017-01-04 at 14 25 03](https://cloud.githubusercontent.com/assets/12121779/21645395/b6f833d8-d289-11e6-85b2-17abb223c8ca.png)


It wasn't working for some accounts (shows `null` instead of the value).
 `total_used_as_percent` is returning the right value so the issue is in `quota_used` method.