### PR TITLE
Put slow orgs in the slow queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
-:concurrency: 10
+:concurrency: 9
 :queues:
   - default
   - mailers
-  - usage_cache
+  - slow

--- a/db/migrate/20170118115646_add_slow_column.rb
+++ b/db/migrate/20170118115646_add_slow_column.rb
@@ -1,0 +1,5 @@
+class AddSlowColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organizations, :slow_jobs, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170113115348) do
+ActiveRecord::Schema.define(version: 20170118115646) do
 
   create_table "audits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "auditable_id"
@@ -312,6 +312,7 @@ ActiveRecord::Schema.define(version: 20170113115348) do
     t.string   "billing_contact"
     t.boolean  "bill_automatically",               default: true,     null: false
     t.string   "technical_contact"
+    t.boolean  "slow_jobs",                        default: false,    null: false
     t.index ["reporting_code"], name: "index_organizations_on_reporting_code", unique: true, using: :btree
     t.index ["state"], name: "index_organizations_on_state", using: :btree
   end


### PR DESCRIPTION
The background queue is being slowed down by long-running jobs. Slow-running jobs should be marked as slow and then put on the slow queue.