### PR TITLE
Improve pending invoices UX

### DIFF
--- a/app/assets/javascripts/site_wide/admin/customers.js
+++ b/app/assets/javascripts/site_wide/admin/customers.js
@@ -46,4 +46,11 @@ $(document).ready(function() {
     });
   });
   $('#tickets-projects-audits-users-tabs a:first').tab('show');
+  $('#pending-invoices-tabs a:first').tab('show');
+  $('#finalized-invoices-tabs a:first').tab('show');
+
+  $(".dropdown-menu#invoices li a").click(function(){
+    $(this).parents(".btn-group").find('.selection').text($(this).text());
+    $(this).parents(".btn-group").find('.selection').val($(this).text());
+  });
 });

--- a/app/assets/stylesheets/components/admin/pending_invoices.scss
+++ b/app/assets/stylesheets/components/admin/pending_invoices.scss
@@ -1,0 +1,118 @@
+$medium-gray: #ccc;
+
+// Invoices dropdown
+div.invoices-dropdown {
+  margin: 10px 10px 10px 10px;
+  float: right;
+}
+
+// Invoices header
+div.pending-invoices h2 {
+  margin-bottom: 20px;
+}
+
+div.finalized-invoices h2 {
+  margin-bottom: 20px;
+}
+
+div.container#invoices-columns {
+  margin-top: 30px;
+  margin-bottom: 30px;
+  padding: 0;
+  width: 80%;
+}
+
+// Pending invoices
+div.pending-invoices .col-md-4 {
+  margin: 3px;
+  background: #fff;
+  border: 1px solid #6d9a3f;
+  border-radius: 4px;
+  height: 65px;
+  width: 32%;
+  max-width: 350px;
+  padding-left: 0;
+}
+
+div.pending-invoices div.container-for-icon {
+  background: #8eb369;
+  float: left;
+  width: 30%;
+  height: 100%;
+  padding: 0;
+}
+
+div.pending-invoices div.icon-container {
+  float: left;
+  margin: 15px 20px 15px 25px;
+  text-align: left;
+  color: white;
+}
+
+div.pending-invoices div.data-container {
+  float: right;
+  text-align: right;
+  font-size: 1em;
+  margin-bottom: 10px;
+}
+
+div.pending-invoices span.invoice-count {
+  color: #6d9a3f;
+  font-size: 1.7em;
+}
+
+// Finalized invoices
+div.finalized-invoices .col-md-4 {
+  margin: 3px;
+  background: #fff;
+  border: 1px solid #8b483e;
+  border-radius: 4px;
+  height: 65px;
+  width: 32%;
+  max-width: 350px;
+  padding-left: 0;
+}
+
+div.finalized-invoices div.container-for-icon {
+  background: #af685d;
+  float: left;
+  width: 30%;
+  height: 100%;
+  padding: 0;
+}
+
+div.finalized-invoices div.icon-container {
+  float: left;
+  margin: 15px 20px 15px 25px;
+  text-align: left;
+  color: white;
+}
+
+div.finalized-invoices div.data-container {
+  float: right;
+  text-align: right;
+  font-size: 1em;
+  margin-bottom: 10px;
+}
+
+div.finalized-invoices span.invoice-count {
+  color: #8b483e;
+  font-size: 1.7em;
+}
+
+// Tabs
+div.container-fluid.pending_invoices_lists {
+  padding-top: 20px;
+}
+
+div.container-fluid.finalized_invoices_lists {
+  padding-top: 20px;
+}
+
+ul.nav.nav-tabs#finalized-invoices-tabs li.active a {
+  border-top: solid 2px #AC5A4D;
+}
+
+ul.nav.nav-tabs#pending-invoices-tabs li.active a {
+  border-top: solid 2px #84b058;
+}

--- a/app/controllers/admin/utilities/pending_invoices_controller.rb
+++ b/app/controllers/admin/utilities/pending_invoices_controller.rb
@@ -8,7 +8,12 @@ module Admin
         else
           @pending_invoices = Billing::Invoice.unfinalized
         end
-        
+
+        @pending_self_service_invoices = Billing::Invoice.unfinalized.self_service
+        @pending_manual_invoices       = Billing::Invoice.unfinalized.manual_invoice
+
+        @finalized_self_service_invoices = Billing::Invoice.finalized.self_service
+        @finalized_manual_invoices       = Billing::Invoice.finalized.manual_invoice
       end
 
       def update

--- a/app/models/billing/invoice.rb
+++ b/app/models/billing/invoice.rb
@@ -23,8 +23,10 @@ module Billing
 
     validates :organization, :year, :month, presence: true
 
-    scope :unfinalized, -> { where(finalized: false) }
-    scope :finalized, -> {   where(finalized: true) }
+    scope :unfinalized,    -> { where(finalized: false) }
+    scope :finalized,      -> {   where(finalized: true) }
+    scope :self_service,   -> { joins(:organization).where('organizations.self_service = ?', true) }
+    scope :manual_invoice, -> { joins(:organization).where('organizations.self_service = ?', false) }
 
     has_many :billing_line_items, :class_name => "Billing::LineItem",
              :foreign_key => 'invoice_id'

--- a/app/views/admin/utilities/pending_invoices/_finalized.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_finalized.html.haml
@@ -1,30 +1,66 @@
 - title "Finalized Invoices"
 
-.pull-right
-  = link_to 'Pending Invoices', admin_utilities_pending_invoices_path, class: 'btn btn-info'
+.invoices-dropdown
+  .btn-group
+    %button.btn.btn-info.dropdown-toggle{"data-toggle" => "dropdown", :type => "button"}
+      Show:
+      %span.selection Finalized Invoices
+      %span.caret
+    %ul.dropdown-menu#invoices{:role => "menu"}
+      %li
+        %a{:href => admin_utilities_pending_invoices_path} Pending Invoices
 
-%h1
-  %i.fa.fa-calculator
-  Finalized Invoices
+.container.finalized-invoices
+  %h2
+    %i.fa.fa-check-square-o
+    Finalized Invoices
+  %hr
+  .container#invoices-columns
+    .row
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-file-text-o.fa-2x
+        .data-container
+          %span.invoice-count
+            = @finalized_invoices.count
+          %br
+          Total finalized invoices
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-calculator.fa-2x
+        .data-container
+          %span.invoice-count
+            = @finalized_self_service_invoices.count
+          %br
+          Self Service Customers
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-pencil-square-o.fa-2x
+        .data-container
+          %span.invoice-count
+            = @finalized_manual_invoices.count
+          %br
+          Manual Invoiced Customers
 
 - if @finalized_invoices.any?
-  .table-responsive
-    %table.table.table-striped.table-hover
-      %thead
-        %th Reporting Code
-        %th Organization
-        %th Month
-        %th SalesForce Invoice
-        %th Stripe Invoice
-      %tbody
-        - for invoice in @finalized_invoices
-          = render partial: 'edit', locals: {invoice: invoice }
-          %tr
-            %td= invoice.organization ? invoice.organization.reporting_code : 'NA'
-            %td= invoice.organization ? invoice.organization.name : 'NA'
-            %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
-            %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'
-            %td= link_to invoice.stripe_invoice_id, invoice.stripe_invoice_link, target: '_blank'
+  .container-fluid.finalized_invoices_lists
+    .centered-tabs
+      %ul.nav.nav-tabs#finalized-invoices-tabs
+        %li{'class' => active_tab?('self_service')}
+          %a{:href => '#self_service', 'data-toggle' => 'tab', 'data-name' => 'self_service'}
+            = t(:self_service)
+        %li{'class' => active_tab?('invoiced')}
+          %a{:href => '#invoiced', 'data-toggle' => 'tab', 'data-name' => 'invoiced'}
+            = t(:manual_invoiced)
+
+    .tab-content
+      .tab-pane#self_service{'class' => active_tab?('self_service')}
+        = render partial: 'admin/utilities/pending_invoices/finalized_self_service'
+      .tab-pane#invoiced{'class' => active_tab?('invoiced')}
+        = render partial: 'admin/utilities/pending_invoices/finalized_manual'
 - else
   .push
   .alert.alert-warning No finalized invoices found.

--- a/app/views/admin/utilities/pending_invoices/_finalized_manual.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_finalized_manual.html.haml
@@ -1,0 +1,19 @@
+.panel.panel-danger
+  .panel-body.panel-padding
+    .table-responsive
+      %table.table.table-striped.table-hover
+        %thead
+          %th Reporting Code
+          %th Organization
+          %th Month
+          %th Total
+          %th SalesForce Invoice
+        %tbody
+          - for invoice in @finalized_manual_invoices
+            = render partial: 'edit', locals: {invoice: invoice }
+            %tr
+              %td= invoice.organization ? invoice.organization.reporting_code : 'NA'
+              %td= invoice.organization ? invoice.organization.name : 'NA'
+              %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
+              %td== £#{number_with_precision(invoice.grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
+              %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'

--- a/app/views/admin/utilities/pending_invoices/_finalized_self_service.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_finalized_self_service.html.haml
@@ -1,0 +1,21 @@
+.panel.panel-danger
+  .panel-body.panel-padding
+    .table-responsive
+      %table.table.table-striped.table-hover
+        %thead
+          %th Reporting Code
+          %th Organization
+          %th Month
+          %th Total
+          %th SalesForce Invoice
+          %th Stripe Invoice
+        %tbody
+          - for invoice in @finalized_self_service_invoices
+            = render partial: 'edit', locals: {invoice: invoice }
+            %tr
+              %td= invoice.organization ? invoice.organization.reporting_code : 'NA'
+              %td= invoice.organization ? invoice.organization.name : 'NA'
+              %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
+              %td== £#{number_with_precision(invoice.grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
+              %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'
+              %td= link_to invoice.stripe_invoice_id, invoice.stripe_invoice_link, target: '_blank'

--- a/app/views/admin/utilities/pending_invoices/_pending.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_pending.html.haml
@@ -1,39 +1,67 @@
 - title "Pending Invoices"
 
-.pull-right
-  = link_to 'Stripe Invoices', admin_utilities_pending_invoices_path(finalized: true), class: 'btn btn-info'
+.invoices-dropdown
+  .btn-group
+    %button.btn.btn-info.dropdown-toggle{"data-toggle" => "dropdown", :type => "button"}
+      Show:
+      %span.selection Pending Invoices
+      %span.caret
+    %ul.dropdown-menu#invoices{:role => "menu"}
+      %li
+        %a{:href => admin_utilities_pending_invoices_path(finalized: true)} Finalized Invoices
 
-%h1
-  %i.fa.fa-calculator
-  Pending Invoices
+
+.container.pending-invoices
+  %h2
+    %i.fa.fa-square-o
+    Pending Invoices
+  %hr
+  .container#invoices-columns
+    .row
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-file-text-o.fa-2x
+        .data-container
+          %span.invoice-count
+            = @pending_invoices.count
+          %br
+          Total pending invoices
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-calculator.fa-2x
+        .data-container
+          %span.invoice-count
+            = @pending_self_service_invoices.count
+          %br
+          Self Service customers
+      .col-md-4
+        .container-for-icon
+          .icon-container
+            %i.fa.fa-pencil-square-o.fa-2x
+        .data-container
+          %span.invoice-count
+            = @pending_manual_invoices.count
+          %br
+          Manual Invoiced customers
 
 - if @pending_invoices.any?
-  .table-responsive
-    %table.table.table-striped.table-hover
-      %thead
-        %th Reporting Code
-        %th Organization
-        %th Month
-        %th Total
-        %th Discount
-        %th Salesforce Invoice
-        %th
-      %tbody
-        - for invoice in @pending_invoices
-          = render partial: 'edit', locals: {invoice: invoice }
-          %tr
-            %td= invoice.organization.reporting_code
-            %td= link_to invoice.organization.name, admin_customer_path(invoice.organization)
-            %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
-            %td== £#{number_with_precision(invoice.grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
-            %td== #{invoice.discount_percent}%
-            %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'
-            %td
-              - if invoice.organization.self_service?
-                = link_to 'Create Stripe Invoice?', '', class: 'btn btn-success', 'data-toggle' => "modal", 'data-target' => "#editInvoice#{invoice.id}"
-            %td
-              = link_to 'Dismiss', admin_utilities_pending_invoice_path(invoice), 'class' => 'btn btn-danger', 'data-method' => "delete", 'data-confirm' => "This can't be undone. Are you sure?"
+  .container-fluid.pending_invoices_lists
+    .centered-tabs
+      %ul.nav.nav-tabs#pending-invoices-tabs
+        %li{'class' => active_tab?('self_service')}
+          %a{:href => '#self_service', 'data-toggle' => 'tab', 'data-name' => 'self_service'}
+            = t(:self_service)
+        %li{'class' => active_tab?('invoiced')}
+          %a{:href => '#invoiced', 'data-toggle' => 'tab', 'data-name' => 'invoiced'}
+            = t(:manual_invoiced)
+
+    .tab-content
+      .tab-pane#self_service{'class' => active_tab?('self_service')}
+        = render partial: 'admin/utilities/pending_invoices/pending_self_service'
+      .tab-pane#invoiced{'class' => active_tab?('invoiced')}
+        = render partial: 'admin/utilities/pending_invoices/pending_manual'
 - else
   .push
   .alert.alert-warning No pending invoices found.
-

--- a/app/views/admin/utilities/pending_invoices/_pending_manual.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_pending_manual.html.haml
@@ -1,0 +1,27 @@
+.panel.panel-success
+  .panel-body.panel-padding
+    .table-responsive
+      %table.table.table-striped.table-hover
+        %thead
+          %th Reporting Code
+          %th Organization
+          %th Month
+          %th Total
+          %th Discount
+          %th Salesforce Invoice
+          %th
+        %tbody
+          - for invoice in @pending_manual_invoices
+            = render partial: 'edit', locals: {invoice: invoice }
+            %tr
+              %td= invoice.organization.reporting_code
+              %td= link_to invoice.organization.name, admin_customer_path(invoice.organization)
+              %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
+              %td== £#{number_with_precision(invoice.grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
+              %td== #{invoice.discount_percent}%
+              %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'
+              %td
+                = form_for invoice, url: admin_utilities_pending_invoice_path(invoice), remote: true do |f|
+                  = f.hidden_field :billing_invoice, :value => invoice
+                  = submit_tag 'Finalize', class: 'btn btn-success', id: 'submit_button'
+              %td= link_to 'Dismiss', admin_utilities_pending_invoice_path(invoice), 'class' => 'btn btn-danger', 'data-method' => "delete", 'data-confirm' => "This can't be undone. Are you sure?"

--- a/app/views/admin/utilities/pending_invoices/_pending_self_service.html.haml
+++ b/app/views/admin/utilities/pending_invoices/_pending_self_service.html.haml
@@ -1,0 +1,24 @@
+.panel.panel-success
+  .panel-body
+    .table-responsive
+      %table.table.table-striped.table-hover
+        %thead
+          %th Reporting Code
+          %th Organization
+          %th Month
+          %th Total
+          %th Discount
+          %th Salesforce Invoice
+          %th
+        %tbody
+          - for invoice in @pending_self_service_invoices
+            = render partial: 'edit', locals: {invoice: invoice }
+            %tr
+              %td= invoice.organization.reporting_code
+              %td= link_to invoice.organization.name, admin_customer_path(invoice.organization)
+              %td== #{Date::MONTHNAMES[invoice.month]} #{invoice.year}
+              %td== £#{number_with_precision(invoice.grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
+              %td== #{invoice.discount_percent}%
+              %td= link_to invoice.salesforce_id, invoice.salesforce_invoice_link, target: '_blank'
+              %td= link_to 'Create Stripe Invoice?', '', class: 'btn btn-success', 'data-toggle' => "modal", 'data-target' => "#editInvoice#{invoice.id}"
+              %td= link_to 'Dismiss', admin_utilities_pending_invoice_path(invoice), 'class' => 'btn btn-danger', 'data-method' => "delete", 'data-confirm' => "This can't be undone. Are you sure?"


### PR DESCRIPTION
- [x] Show in the UI whether the customer is self service or invoiced.
- [x] Allow all invoices to be “finalized”, which means they’ve been paid.
- [x] When someone presses the “Finalize” button for a self service invoice they see the modal that appears for Stripe payment.
- [x] When someone presses the “Finalize” button for an invoiced customer, it just marks it as finalized.
- [x] The toggle button lets us switch between “Finalized” and “Pending” invoices. 
- [x] Finalized invoices all link to their Salesforce invoices. They also link to their Stripe invoices if the account is self service.

---
## Pending invoices (Self Service Customers).

![screen shot 2017-01-31 at 15 50 56](https://cloud.githubusercontent.com/assets/12121779/22472353/4194ffdc-e7cd-11e6-9364-47b6a3c8663f.png)

---

## Pending invoices (Manual invoiced Customers).

![screen shot 2017-01-31 at 15 51 07](https://cloud.githubusercontent.com/assets/12121779/22472389/64c2252a-e7cd-11e6-874f-7c19a23bb6c7.png)

---

## Finalized invoices.

![screen shot 2017-01-31 at 15 50 32](https://cloud.githubusercontent.com/assets/12121779/22472429/884cd5e4-e7cd-11e6-89b0-3c9a85008da3.png)

---
## Invoiced dropdown.

![dropdown](https://cloud.githubusercontent.com/assets/12121779/22472593/037b4d72-e7ce-11e6-9c63-b2dcd28661d4.png)
