### PR TITLE
Select which orgs should get cached.

### DIFF
--- a/app/jobs/usage_cache_refresh_job.rb
+++ b/app/jobs/usage_cache_refresh_job.rb
@@ -32,7 +32,7 @@ class UsageCacheRefreshJob < ApplicationJob
   end
 
   def organizations
-    Organization.active.shuffle
+    Organization.active.for_usage_tracking.shuffle
   end
 
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -63,7 +63,8 @@ class Organization < ApplicationRecord
   scope :billable,              -> { where(test_account: false, bill_automatically: true) }
   scope :cloud,                 -> { all.select(&:cloud?) }
   scope :active,                -> { where(state: 'active')}
-  scope :self_service,          -> { where('self_service = true') }
+  scope :for_usage_tracking,    -> { where(track_usage:  true) }
+  scope :self_service,          -> { where(self_service: true) }
   scope :pending,               -> { where(state: 'fresh')}
   scope :frozen,                -> { where(state: 'frozen')}
   scope :pending_without_users, -> { all.select{|o| o.fresh? && o.users.count == 0}}

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -42,6 +42,8 @@ class Project < ApplicationRecord
 
   serialize :quota_set
 
+  scope :for_usage_tracking, -> { with_deleted.joins(:organization).where("organizations.track_usage = ?", true) }
+
   def quota_set
     read_attribute(:quota_set) || StartingQuota['standard']
   end

--- a/db/migrate/20170130142912_add_track_usage_column.rb
+++ b/db/migrate/20170130142912_add_track_usage_column.rb
@@ -1,0 +1,6 @@
+class AddTrackUsageColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organizations, :track_usage, :boolean, null: false, default: true
+    add_index  :organizations, :track_usage, where: "track_usage"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170119201153) do
+ActiveRecord::Schema.define(version: 20170130142912) do
 
   create_table "api_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -320,8 +320,10 @@ ActiveRecord::Schema.define(version: 20170119201153) do
     t.boolean  "bill_automatically",               default: true,     null: false
     t.string   "technical_contact"
     t.boolean  "slow_jobs",                        default: false,    null: false
+    t.boolean  "track_usage",                      default: true,     null: false
     t.index ["reporting_code"], name: "index_organizations_on_reporting_code", unique: true, using: :btree
     t.index ["state"], name: "index_organizations_on_state", using: :btree
+    t.index ["track_usage"], name: "index_organizations_on_track_usage", using: :btree
   end
 
   create_table "organizations_products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
This allows us to exempt some organizations from usage tracking if necessary.