### PR TITLE
Round up to whole TBhs.

### DIFF
--- a/app/lib/billing/images.rb
+++ b/app/lib/billing/images.rb
@@ -59,18 +59,18 @@ module Billing
             ending *= states.last.size
           end
 
-          return (start + middle + ending).round(2)
+          return (start + middle + ending).ceil
         else
           # Only one sample for this period
           if billable?(states.first.event_name)
-            return (seconds_to_whole_hours(to - from) * states.first.size).round(2)
+            return (seconds_to_whole_hours(to - from) * states.first.size).ceil
           else
             return 0
           end
         end
       else
         if previous_state && billable?(previous_state.event_name)
-          return (seconds_to_whole_hours(to - from) * previous_state.size).round(2)
+          return (seconds_to_whole_hours(to - from) * previous_state.size).ceil
         else
           return 0
         end

--- a/app/lib/billing/storage_objects.rb
+++ b/app/lib/billing/storage_objects.rb
@@ -25,7 +25,7 @@ module Billing
         last = measurement
         gb * seconds
       end.sum
-      gbs / 3_600_000.0
+      (gbs / 3_600_000.0).ceil
     end
 
   end

--- a/app/lib/billing/volumes.rb
+++ b/app/lib/billing/volumes.rb
@@ -60,18 +60,18 @@ module Billing
             ending *= gigabytes_to_terabytes(states.last.size)
           end
 
-          return (start + middle + ending).round(2)
+          return (start + middle + ending).ceil
         else
           # Only one sample for this period
           if billable?(states.first.event_name)
-            return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(states.first.size)).round(2)
+            return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(states.first.size)).ceil
           else
             return 0
           end
         end
       else
         if previous_state && billable?(previous_state.event_name)
-          return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(previous_state.size)).round(2)
+          return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(previous_state.size)).ceil
         else
           return 0
         end
@@ -164,7 +164,7 @@ module Billing
     end
 
     def self.gigabytes_to_terabytes(gigabytes)
-      (gigabytes / 1024.0).round(2)
+      (gigabytes / 1024.0).ceil
     end
 
     def self.volume_name

--- a/app/views/admin/usage/results/_ips.html.haml
+++ b/app/views/admin/usage/results/_ips.html.haml
@@ -4,9 +4,10 @@
   %p
     %strong Current Quota:
     == #{project.quota_set['network']['floatingip']} addresses
-  %p
-    %strong Cost:
-    == £#{number_with_precision(ip_quota_total, :delimiter => ',', :separator => '.', :precision => 2)}
+  - if current_organization.show_costs?
+    %p
+      %strong Cost:
+      == £#{number_with_precision(ip_quota_total, :delimiter => ',', :separator => '.', :precision => 2)}
   - if ip_quotas && ip_quotas.any?
     .table-responsive
       %table.table.table-hover.phone-bill


### PR DESCRIPTION
This should make Stronghold's billing match Salesforce because Salesforce only deals in whole TBh so any fractions are always rounded up.