### PR TITLE
[Stronghold] Set the Unicorn User

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -12,6 +12,10 @@
 # more will usually help for _short_ waits on databases/caches.
 worker_processes 4
 
+# Set which user to spawn unicorn worker processes as per:
+# http://bogomips.org/unicorn/Unicorn/Configurator.html#method-i-user
+user 'rails'
+
 # listen on both a Unix domain socket and a TCP port,
 # we use a shorter backlog for quicker failover when busy
 listen "/var/run/rails/stronghold/unicorn.sock", :backlog => 64


### PR DESCRIPTION
Currently stronghold rails process is running as root, so this change set the user to 'rails' via unicorn.rb configuration. There may need to be some manual chowning of any state files outside of unicorn's scope, but that may have been altered as root (therefore will cause issues if not chowned to 'rails'). PID files *should* be ok.

Addresses PD-2925