### PR TITLE
Fix usage alerts frequency

### DIFF
--- a/app/jobs/usage_alert_organization_job.rb
+++ b/app/jobs/usage_alert_organization_job.rb
@@ -1,8 +1,12 @@
 class UsageAlertOrganizationJob < ActiveJob::Base
+  ALERT_INTERVAL = Time.now - 90.days
   queue_as :default
 
   def perform(organization)
     organization = OrganizationUsageDecorator.new(organization)
-    Mailer.quota_limits_alert(organization.id).deliver_now if organization.over_threshold?
+    if organization.over_threshold? && organization.last_alerted_for_low_quotas_at < ALERT_INTERVAL
+      Mailer.quota_limits_alert(organization.id).deliver_now
+      organization.touch(:last_alerted_for_low_quotas_at)
+    end
   end
 end

--- a/clock.rb
+++ b/clock.rb
@@ -64,9 +64,9 @@ if Rails.env.production? || Rails.env.staging?
     FillAuditBlanksJob.perform_later
   end
 
-  # every(1.day, 'organization_usage_near_threshold_alert', :at => '15:00') do
-  #   UsageAlertJob.perform_later
-  # end
+  every(1.day, 'organization_usage_near_threshold_alert', :at => '15:00') do
+    UsageAlertJob.perform_later
+  end
 
 end
 

--- a/db/migrate/20170510095217_add_last_usage_alert_to_organization.rb
+++ b/db/migrate/20170510095217_add_last_usage_alert_to_organization.rb
@@ -1,0 +1,5 @@
+class AddLastUsageAlertToOrganization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organizations, :last_alerted_for_low_quotas_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -321,6 +321,7 @@ ActiveRecord::Schema.define(version: 20170522141111) do
     t.string   "technical_contact"
     t.boolean  "slow_jobs",                        default: false,    null: false
     t.boolean  "track_usage",                      default: true,     null: false
+    t.datetime "last_alerted_for_low_quotas_at"
     t.index ["reporting_code"], name: "index_organizations_on_reporting_code", unique: true, using: :btree
     t.index ["state"], name: "index_organizations_on_state", using: :btree
     t.index ["track_usage"], name: "index_organizations_on_track_usage", using: :btree


### PR DESCRIPTION
[APP-536](https://datacentred.atlassian.net/browse/APP-536)

> Trial users have very small quotas and are almost instantly spammed with usage alert emails.
Make it so the email alerts the user and then store a timestamp in the database of the current time. This timestamp is then checked whenever we're sending out new alerts and a new alert is only sent if a certain amount of time has elapsed.
Once every 90 days is probably enough.