### PR TITLE
Automatically remove users from temporary assignments

### DIFF
--- a/app/assets/stylesheets/components/admin/customers.scss
+++ b/app/assets/stylesheets/components/admin/customers.scss
@@ -173,18 +173,6 @@ ul#billing_address-list li {
   padding: 8px 8px 0px 0;
 }
 
-div#temporary-memberships.col-md-12 {
-  margin-top: 50px;
-}
-
-input#create-org-membership {
-  margin-top: 15px;
-}
-
-input#delete-org-membership {
-  margin-top: 15px;
-}
-
 td.first-column {
   font-weight: 500;
   width: 280px;
@@ -217,6 +205,39 @@ td.contact-type {
   font-weight: 500;
   width: 150px;
   background-color: rgb(249, 249, 249);
+}
+
+input#create-org-membership {
+  margin-top: 15px;
+}
+
+input#delete-org-membership {
+  margin-top: 15px;
+}
+
+@media (min-width: 1570px) {
+  div.membership-options {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+@media (min-width: 1569px) {
+  div.membership-options {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+div.membership-options .row {
+  margin: 5px 5px 5px 0;
+  width: 100%;
+  padding: 10px 10px 5px 10px;
+  border: 1px solid rgb(221,221,221);
+  border-radius: 5px;
+  background-color: rgb(249, 249, 249);
+  text-align: center;
+  vertical-align: middle;
 }
 
 div#state-container {

--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -26,13 +26,14 @@ module Admin
     end
 
     def show
-      @organization    = Organization.find(params[:id]) if params[:id]
-      @usage_decorator = UsageDecorator.new(@organization)
-      @tickets         = decorated_tickets(@organization)
-      @users           = @organization.users
-      @audits          = Audit.for_organization_and_user(@organization, current_user).order('created_at DESC').first(7)
-      @projects        = @organization.projects.includes(:users)
-      @invites         = @organization.invites.incomplete
+      @organization      = Organization.find(params[:id]) if params[:id]
+      @usage_decorator   = UsageDecorator.new(@organization)
+      @tickets           = decorated_tickets(@organization)
+      @users             = @organization.users
+      @audits            = Audit.for_organization_and_user(@organization, current_user).order('created_at DESC').first(7)
+      @projects          = @organization.projects.includes(:users)
+      @invites           = @organization.invites.incomplete
+      @staff_membership  = OrganizationUser.find_by(organization: @organization, user: current_user)
     end
 
     def edit

--- a/app/controllers/admin/organization_assignments_controller.rb
+++ b/app/controllers/admin/organization_assignments_controller.rb
@@ -3,30 +3,37 @@ class Admin::OrganizationAssignmentsController < AdminBaseController
   before_action :fetch_organization
 
   def create
-    @organization_user = OrganizationUser.create organization_id: @organization_id, user_id: current_user.id
+    @organization_user = OrganizationUser.create organization: @organization,
+                                                 user:         current_user,
+                                                 duration:     OrganizationUser::DEFAULT_MEMBERSHIP_DURATION_IN_HOURS
     if @organization_user.save
-      redirect_to admin_customer_path(@organization_id), notice: "You have added yourself to this account."
+      redirect_to admin_customer_path(@organization), notice: "You have added yourself to this account."
     else
-      redirect_to admin_customer_path(@organization_id), alert: model_errors_as_html(@organization_user)
+      redirect_to admin_customer_path(@organization), alert: model_errors_as_html(@organization_user)
     end
   end
 
   def destroy
-    @organization_user = OrganizationUser.where(:organization_id => @organization_id, :user_id => current_user.id).first
+    @organization_user = OrganizationUser.find_by organization: @organization, user: current_user
     if @organization_user.destroy
-      redirect_to admin_customer_path(@organization_id), notice: "You have removed yourself from this account."
+      redirect_to admin_customer_path(@organization), notice: "You have removed yourself from this account."
     else
-      redirect_to admin_customer_path(@organization_id), alert: model_errors_as_html(@organization_user)
+      redirect_to admin_customer_path(@organization), alert: model_errors_as_html(@organization_user)
+    end
+  end
+
+  def update
+    @organization_user = OrganizationUser.find_by organization: @organization, user: current_user
+    if @organization_user.reset!
+      redirect_to admin_customer_path(@organization), notice: "You have restarted your membership timer."
+    else
+      redirect_to admin_customer_path(@organization), alert: model_errors_as_html(@organization_user)
     end
   end
 
   private
 
   def fetch_organization
-    @organization_id = params[:organization][:id]
-  end
-
-  def create_params
-    params.permit(:id)
+    @organization ||= Organization.find params[:id]
   end
 end

--- a/app/helpers/organization_helper.rb
+++ b/app/helpers/organization_helper.rb
@@ -11,9 +11,16 @@ module OrganizationHelper
     options_for_select(current_organization.users.map(&:email), selected)
   end
 
-  def organizations_for_select
-    organizations = current_user.organizations.map{|org| [truncate(org.name, length: 18, separator: ' ', omission: '…'), org.id]}
+  def organizations_for_select    
+    organizations = current_user.organization_users.map{|ou| [organization_name(ou), ou.organization.id]}
     organizations.unshift(["Accounts:", ""])
     options_for_select(organizations, selected: current_organization.id, disabled: "")
+  end
+
+  private
+
+  def organization_name(ou)
+    name = truncate(ou.organization.name, length: 18, separator: ' ', omission: '…')
+    ou.temporary? ? "🕒 #{name}" : name
   end
 end

--- a/app/lib/stronghold/error/base.rb
+++ b/app/lib/stronghold/error/base.rb
@@ -1,0 +1,5 @@
+module Stronghold
+  module Error
+    class Base < StandardError; end
+  end
+end

--- a/app/lib/stronghold/error/temporary_membership_expired_error.rb
+++ b/app/lib/stronghold/error/temporary_membership_expired_error.rb
@@ -1,0 +1,5 @@
+module Stronghold
+  module Error
+    class TemporaryMembershipExpiredError < ::Stronghold::Error::Base; end
+  end
+end

--- a/app/views/admin/customers/_assign_organization.html.haml
+++ b/app/views/admin/customers/_assign_organization.html.haml
@@ -1,17 +1,33 @@
 - if current_user.organization_ids.include?(@organization.id)
-  - if current_user.primary_organization != @organization
-    %strong
-      %i.fa.fa-info-circle
-      You are a member of this organization.
-      = form_for :organization, url: admin_organization_assignment_path(@organization.id), :method => 'delete', :id => 'assign_org_form', :class => "form-inline" do |f|
-        .form-group
-          = f.hidden_field :id
-          = f.submit 'Delete membership', class: 'btn btn-danger', id: 'delete-org-membership'
+  - if @staff_membership.temporary?
+    %div.membership-options
+      .row
+        %i.fa.fa-info-circle
+        You are a temporary member of this organization.
+        = form_for :organization, url: admin_organization_assignment_path(@organization), :method => 'delete', :id => 'assign_org_form', :class => "form-inline" do |f|
+          .form-group
+            = f.hidden_field :id
+            = f.submit 'Remove', class: 'btn btn-danger btn-sm', id: 'delete-org-membership'
+      .row
+        %i.fa.fa-clock-o
+        Remaining time:
+        = distance_of_time_in_words(@staff_membership.expires_at, Time.now.utc)
+        %p
+          = form_for :organization, url: admin_organization_assignment_path(@organization), :method => 'patch', :class => "form-inline" do |f|
+            .form-group
+              = f.hidden_field :id
+              = f.submit 'Restart', class: 'btn btn-info btn-sm'
+  - else
+    %div.membership-options
+      .row
+        %i.fa.fa-info-circle
+        You are a member of this organization.
 - else
-  %strong
-    %i.fa.fa-info-circle
-    You can assign yourself as a temporary member of this organization.
-  = form_for :organization, url: admin_organization_assignments_path, :method => 'post', :id => 'assign_org_form', :class => "form-inline" do |f|
-    .form-group
-      = f.hidden_field :id
-      = f.submit 'Create membership', class: 'btn btn-primary', id: 'create-org-membership'
+  %div.membership-options
+    .row
+      %i.fa.fa-info-circle
+      You can assign yourself as a temporary member of this organization.
+    .row
+      = form_for :organization, url: admin_organization_assignments_path(id: @organization), :method => 'post', :id => 'assign_org_form', :class => "form-inline" do |f|
+        .form-group
+          = f.submit 'Create membership', class: 'btn btn-info btn-sm', id: 'create-org-membership'

--- a/app/views/admin/customers/_info.html.haml
+++ b/app/views/admin/customers/_info.html.haml
@@ -51,7 +51,3 @@
   .col-md-12
     .pull-right
       = link_to 'Edit', edit_admin_customer_path(@organization), class: 'btn btn-primary information-edit-dashboard'
-
-.row
-  .col-md-12#temporary-memberships
-    = render partial: 'admin/customers/assign_organization'

--- a/app/views/admin/customers/show.html.haml
+++ b/app/views/admin/customers/show.html.haml
@@ -75,7 +75,18 @@
               = render partial: "admin/customers/invites", locals: {invites: @invites, organization: @organization}
 
     .col-lg-3.col-md-4.col-sm-3.admin-sidebar
+      .panel.panel-info
+        .panel-heading
+          %i.fa.fa-users
+          Account Memberships
+        .panel-body.panel-padding
+          = render partial: 'admin/customers/assign_organization'
+
       %div.panel.panel-info
+        .panel.panel-info
+          .panel-heading
+            %i.fa.fa-credit-card
+            Payment Type
         .panel-body.panel-padding
           %div.toggle-grid
             = render partial: 'admin/customers/toggles'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
       resources :audits, only: [:show]
       resources :states, only: [:show]
 
-      resources :organization_assignments, only: [:create, :destroy]
+      resources :organization_assignments, only: [:create, :destroy, :update]
       resources :quotas, except: [:create, :new, :destroy, :show] do
         member do
           post 'mail'

--- a/db/migrate/20170526133710_add_membership_duration_to_organizations_users.rb
+++ b/db/migrate/20170526133710_add_membership_duration_to_organizations_users.rb
@@ -1,0 +1,5 @@
+class AddMembershipDurationToOrganizationsUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :organizations_users, :duration, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170524145512) do
+ActiveRecord::Schema.define(version: 20170526133710) do
 
   create_table "api_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -341,6 +341,7 @@ ActiveRecord::Schema.define(version: 20170524145512) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.boolean  "primary",         default: false, null: false
+    t.integer  "duration"
     t.index ["organization_id"], name: "index_organizations_users_on_organization_id", using: :btree
     t.index ["user_id"], name: "index_organizations_users_on_user_id", using: :btree
   end

--- a/test/acceptance/admin/temporary_assignment_test.rb
+++ b/test/acceptance/admin/temporary_assignment_test.rb
@@ -1,0 +1,43 @@
+require_relative '../acceptance_test_helper'
+
+class TemporaryAssignmentTests < CapybaraTestCase
+
+  def setup
+    @user = User.find_by_email('capybara@test.com')
+    @organization = Organization.find_by_name 'capybara'
+    @organization.update_attributes reference: 'datacentred'
+    @user.roles.first.update_attributes power_user: true
+    login
+  end
+
+  def test_satff_can_create_temporary_membership
+    @organization2 = Organization.create(name: 'test-organization2')
+    @organization2.update_attributes(self_service: false)
+    visit admin_customer_path(@organization2)
+    find('input#create-org-membership').click
+    page.has_content?('You have added yourself to this account.')
+    page.has_content?('Remaining time: about 4 hours')
+    select('test-organization2', :from => 'select-organization')
+    sleep(5)
+    page.has_content?('Account changed successfully.')
+
+    visit('/')
+    page.has_content?('Welcome')
+  end
+
+  def test_user_cant_navigate_expired_membership
+    @organization3 = Organization.create(name: 'test-organization3')
+    @organization3.update_attributes(self_service: false)
+    visit admin_customer_path(@organization3)
+    find('input#create-org-membership').click
+
+    select('test-organization3', :from => 'select-organization')
+    sleep(5)
+    page.has_content?('Account changed successfully.')
+
+    Timecop.freeze(Time.now + 5.hours) do
+      visit('/')
+      page.has_content?('Your temporary mermbership to Test-Organization3 has expired.')
+    end
+  end
+end

--- a/test/unit/controllers/admin/organization_assignments_controller_test.rb
+++ b/test/unit/controllers/admin/organization_assignments_controller_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class Admin::OrganizationAssignmentsControllerTest < ActionController::TestCase
+  setup do
+    @organization = Organization.make! state: 'active', reference: STAFF_REFERENCE
+    @organization2 = Organization.make! state: 'active'
+    @organization3 = Organization.make! state: 'active'
+
+    @user = User.make!(organizations: [@organization])
+    @organization.update_attributes self_service: false
+    @role = Role.make!(organization: @organization, power_user: true)
+    @user.update_attributes(roles: [@role])
+    @membership = OrganizationUser.create! organization: @organization3,
+                                           user:         @user,
+                                           duration:     4
+    log_in(@user)
+  end
+
+  test 'staff member can temporarily assign themself to an organization' do
+    refute @user.organizations.include?(@organization2)
+    post :create, params: { id: @organization2.id }
+    assert_redirected_to admin_customer_path(@organization2.id)
+    assert flash[:notice].length.positive?
+    assert_equal 'You have added yourself to this account.', flash[:notice]
+    assert @user.organizations.include?(@organization2)
+  end
+
+  test 'staff member can remove themself from an organization' do
+    assert @user.organizations.include?(@organization3)
+    delete :destroy, params: { id: @organization3.id }
+    assert_redirected_to admin_customer_path(@organization3.id)
+    assert flash[:notice].length.positive?
+    assert_equal 'You have removed yourself from this account.', flash[:notice]
+    refute @user.organizations.include?(@organization3)
+  end
+
+  test 'staff member can restart membership duration timer' do
+    time1 = @membership.expires_at
+    Timecop.freeze(Time.now + 20.minutes) do
+      put :update, params: { id: @organization3.id }
+      assert_redirected_to admin_customer_path(@organization3.id)
+      assert flash[:notice].length.positive?
+      assert_equal 'You have restarted your membership timer.', flash[:notice]
+      assert @membership.reload.expires_at > time1
+    end
+  end
+
+  def teardown
+    DatabaseCleaner.clean
+  end
+end

--- a/test/unit/models/organization_user/organization_user_test.rb
+++ b/test/unit/models/organization_user/organization_user_test.rb
@@ -43,5 +43,12 @@ class TestOrganizationUser < CleanTest
     end
   end
 
+  def test_memberships_is_deleted_if_its_expired
+    relation = OrganizationUser.create(user: @user, organization: @organization, duration: 4)
+    relation.update_attributes(updated_at: Time.now.utc - 5.hours)
+    assert_raises Stronghold::Error::TemporaryMembershipExpiredError do
+      relation.reload
+    end
+  end
 
 end


### PR DESCRIPTION
[APP-534](https://datacentred.atlassian.net/browse/APP-534)

- [x] Add a temp flag to the organizations_users table. Set it when memberships are created.
- [x] Show a time remaining on the admin page (default to four hours).
- [x] Add a button to reset the clock back to four hours.
- [x] Add a background job to purge temporary assignments every five minutes.
- [x] Use notifications to let people know when they've been removed.
<img width="282" alt="screen shot 2017-05-30 at 14 44 51" src="https://cloud.githubusercontent.com/assets/12121779/26586263/9b7b4066-4546-11e7-9031-61ad8bf3c47e.png">
<img width="315" alt="screen shot 2017-05-30 at 14 44 24" src="https://cloud.githubusercontent.com/assets/12121779/26586262/9b7b1974-4546-11e7-9c95-c919797f47dc.png">
<img width="322" alt="screen shot 2017-05-30 at 14 44 02" src="https://cloud.githubusercontent.com/assets/12121779/26586264/9bb0b75a-4546-11e7-8ce0-4ae017815da2.png">
