### PR TITLE
Fix NoMethodError in usage alert job.

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -172,10 +172,6 @@ class Organization < ApplicationRecord
     true
   end
 
-  def last_alerted_for_low_quotas_at
-    read_attribute(:last_alerted_for_low_quotas_at) || Time.at(0)
-  end
-
   private
 
   def generate_reference

--- a/db/migrate/20170524145512_change_last_alert_column_default.rb
+++ b/db/migrate/20170524145512_change_last_alert_column_default.rb
@@ -1,0 +1,5 @@
+class ChangeLastAlertColumnDefault < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :organizations, :last_alerted_for_low_quotas_at, "1970-01-01 01:00:00"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170522141111) do
+ActiveRecord::Schema.define(version: 20170524145512) do
 
   create_table "api_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -322,6 +322,7 @@ ActiveRecord::Schema.define(version: 20170522141111) do
     t.boolean  "slow_jobs",                        default: false,    null: false
     t.boolean  "track_usage",                      default: true,     null: false
     t.datetime "last_alerted_for_low_quotas_at"
+    t.datetime "last_alerted_for_low_quotas_at",               default: '1970-01-01 01:00:00'
     t.index ["reporting_code"], name: "index_organizations_on_reporting_code", unique: true, using: :btree
     t.index ["state"], name: "index_organizations_on_state", using: :btree
     t.index ["track_usage"], name: "index_organizations_on_track_usage", using: :btree


### PR DESCRIPTION
<img width="1131" alt="screen shot 2017-05-24 at 15 33 31" src="https://cloud.githubusercontent.com/assets/12121779/26408686/64fa3114-4096-11e7-82ba-fa5cb726570f.png">

The column `last_alerted_for_low_quotas_at` might be NULL if no alert has been sent. so it's raising a NoMethodError when trying to read it.