### PR TITLE
Usage data changes

### DIFF
--- a/app/controllers/admin/usage_controller.rb
+++ b/app/controllers/admin/usage_controller.rb
@@ -22,10 +22,6 @@ module Admin
         @to_date, @from_date = to_date, from_date
 
         case params[:format].try :downcase
-        when 'json'
-          render json: usage_data_as_json(@usage, @usage_decorator.grand_total)
-        when 'xml'
-          render xml: usage_data_as_xml(@usage, @usage_decorator.grand_total)
         when 'csv'
           headers['Content-Type'] ||= 'text/csv'
           render text: usage_data_as_csv(@usage)

--- a/app/controllers/support/usage_controller.rb
+++ b/app/controllers/support/usage_controller.rb
@@ -26,15 +26,6 @@ module Support
                                            year: @year, month: @month).first&.updated_at
 
       respond_to do |format|
-        format.json {
-          render json: usage_data_as_json(@usage, @usage_decorator.grand_total)
-        }
-        format.xml {
-          render xml: usage_data_as_xml(@usage, @usage_decorator.grand_total)
-        }
-        format.csv {
-          render text: usage_data_as_csv(@usage)
-        }
         format.html
       end
     end

--- a/app/decorators/usage_decorator.rb
+++ b/app/decorators/usage_decorator.rb
@@ -16,112 +16,90 @@ class UsageDecorator < ApplicationDecorator
   
   def usage_data(force: false)
     @usage_data ||= UsageStorage.fetch(year: year, month: month, organization_id: model.id, force: force) do
-      model.projects.with_deleted.where("created_at < ?", to_date).select{|t| t.deleted_at.nil? || t.deleted_at > from_date}.inject({}) do |acc, project|
-        ip_quota_usage = Billing::IpQuotas.usage(project.uuid, from_date, to_date)
-        acc[project] = {
-          instance_usage: Billing::Instances.usage(project.uuid, from_date, to_date),
-          volume_usage: Billing::Volumes.usage(project.uuid, from_date, to_date),
-          image_usage: Billing::Images.usage(project.uuid, from_date, to_date),
-          ip_quota_usage: ip_quota_usage,
-          ip_quota_hours: ip_quota_hours(project, ip_quota_usage),
-          object_storage_usage: Billing::StorageObjects.usage(project.uuid, from_date, to_date),
-          current_ip_quota: project.quota_set['network']['floatingip'].to_i,
-          ip_quota_total: ip_quota_cost(project, ip_quota_usage).nearest_penny,
-          load_balancer_usage: Billing::LoadBalancers.usage(project.uuid, from_date, to_date),
-          vpn_connection_usage: Billing::VpnConnections.usage(project.uuid, from_date, to_date)
+      model.projects.with_deleted.where("created_at < ?", to_date).select{|t| t.deleted_at.nil? || t.deleted_at > from_date}.map do |project|
+        {
+          id: project.uuid,
+          name: project.name,
+          usage: {
+            images:         Billing::Images.usage(project.uuid, from_date, to_date),
+            instances:      Billing::Instances.usage(project.uuid, from_date, to_date),
+            ips:            Billing::IpQuotas.usage(project, from_date, to_date),
+            load_balancers: Billing::LoadBalancers.usage(project.uuid, from_date, to_date),
+            object_storage: Billing::StorageObjects.usage(project.uuid, from_date, to_date),
+            volumes:        Billing::Volumes.usage(project.uuid, from_date, to_date),
+            vpns:           Billing::VpnConnections.usage(project.uuid, from_date, to_date)
+          }
         }
-        acc
       end
     end
+    {
+      last_updated_at: Billing::Usage.find_by(organization_id: model.id, year: year, month: month)&.updated_at,
+      projects:        @usage_data
+    }
   end
 
   def instance_total(project_id, flavor_id=nil)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        results = results[:instance_usage]
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        results = results[:usage][:instances]
         if flavor_id
-          results = results.select{|i| i[:flavor][:flavor_id] == flavor_id}
+          results = results.select{|i| i[:current_flavor][:id] == flavor_id}
         end
-        return results.collect{|i| i[:cost]}.sum
+        return results.sum{|i| i[:usage].sum{|u| u[:cost][:value]}}.nearest_penny
       end
     end
     return 0
   end
 
   def volume_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return results[:volume_usage].sum{|i| i[:cost]}.ceil
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return results[:usage][:volumes].sum{|i| i[:usage].sum{|u| u[:cost][:value]}}.nearest_penny
       end
     end
     return 0
   end
 
   def image_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return results[:image_usage].sum{|i| i[:cost]}.ceil
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return results[:usage][:images].sum{|i| i[:usage].sum{|u| u[:cost][:value]}}.nearest_penny
       end
     end
     return 0
   end
 
   def load_balancer_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return results[:load_balancer_usage]&.collect{|i| i[:cost]}&.sum || 0
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return results[:usage][:load_balancers]&.sum{|i| i[:usage].sum{|u| u[:cost][:value]}}.nearest_penny || 0
       end
     end
     return 0
   end
 
   def vpn_connection_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return results[:vpn_connection_usage]&.collect{|i| i[:cost]}&.sum || 0
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return results[:usage][:vpns]&.sum{|i| i[:usage].sum{|u| u[:cost][:value]}}.nearest_penny || 0
       end
     end
     return 0
   end
 
   def ip_quota_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return ip_quota_cost(project, results[:ip_quota_usage]).nearest_penny
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return results[:usage][:ips][:usage].sum{|u| u[:cost][:value]}.nearest_penny
       end
     end
     return 0
   end
 
-  def ip_quota_hours(project, results)
-    results = results || []
-    if results.none?
-      quota = [project.quota_set['network']['floatingip'].to_i - 1, 0].max
-      return (((to_date - from_date) / 60.0) / 60.0).round * quota
-    else
-      start = from_date
-      hours = results.collect do |quota|
-        period = (((quota.recorded_at - start) / 60.0) / 60.0).round
-        start = quota.recorded_at
-        q = quota.previous ? quota.previous : 1
-        (q - 1) * period
-      end.sum
-
-      q = [(results.last.quota || 1) - 1, 0].max
-      period = (((to_date - results.last.recorded_at) / 60.0) / 60.0).round
-      hours += (q * period)
-      return hours
-    end
-  end
-
-  def ip_quota_cost(project, results)
-    ip_quota_hours(project, results) * RateCard.ip_address
-  end
-
   def object_storage_total(project_id)
-    usage_data.each do |project, results|
-      if(project_id == project.id)
-        return (results[:object_storage_usage] * RateCard.object_storage).nearest_penny
+    usage_data[:projects].each do |results|
+      if(project_id == results[:id])
+        return (results[:usage][:object_storage][:usage].sum{|u| u[:cost][:value]}).nearest_penny
       end
     end
     return 0
@@ -139,7 +117,7 @@ class UsageDecorator < ApplicationDecorator
   end
 
   def sub_total
-    model.projects.with_deleted.collect{|t| total(t.id)}.sum
+    model.projects.with_deleted.collect{|t| total(t.uuid)}.sum
   end
 
   def discounts?

--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -48,18 +48,6 @@ module UsageHelper
     end
   end
 
-  def usage_data_with_total(data, total)
-    Hash[data.map{|k,v| [k.name,v]}].merge(total: total.round(2))
-  end
-
-  def usage_data_as_json(data, total)
-    usage_data_with_total(data, total).to_json
-  end
-
-  def usage_data_as_xml(data, total)
-    usage_data_with_total(data, total).to_xml(root: 'usage')
-  end
-
   def flavors
     @flavors ||= Hash[Billing::InstanceFlavor.all.map{|f| [f.flavor_id, f.name]}]
   end
@@ -68,29 +56,29 @@ module UsageHelper
     CSV.generate do |csv|
       csv << ["Project", "Type", "Sub-Type", "ID", "Name", "Amount", "Unit", "Cost (£)"]
       data.each do |project, usage|
-        usage[:instance_usage].each do |instance|
+        usage[:instances].each do |instance|
           instance[:billable_hours].each do |flavor_id, hours|
             csv << [project.name, "Instance", flavors[flavor_id] + (instance[:windows] ? " (Windows)" : ""), instance[:uuid], instance[:name], hours, 'hours', instance[:cost_by_flavor][flavor_id].nearest_penny]
           end
         end
 
-        usage[:volume_usage].each do |volume|
+        usage[:volumes].each do |volume|
           csv << [project.name, "Volume", volume[:volume_type_name], volume[:id], volume[:name], volume[:terabyte_hours], 'TB/h', volume[:cost]]
         end
-        usage[:image_usage].each do |image|
+        usage[:images].each do |image|
           csv << [project.name, "Image", nil, image[:id], image[:name], image[:terabyte_hours], 'TB/h', image[:cost]]
         end
-        csv << [project.name, "Object Storage", nil, nil, nil, usage[:object_storage_usage].round(2), 'TB/h', (usage[:object_storage_usage] * RateCard.object_storage).nearest_penny]
+        csv << [project.name, "Object Storage", nil, nil, nil, usage[:object_storage].round(2), 'TB/h', (usage[:object_storage] * RateCard.object_storage).nearest_penny]
         usage[:ip_quota_usage].each do |ip_quota|
           change = "From #{ip_quota.previous || '0'} IPs to #{ip_quota.quota} IPs"
           csv << [project.name, "Quota Change", nil, nil, ip_quota.recorded_at, change, 'floating IPs', nil]
         end
         csv << [project.name, "IP quota", nil, nil, nil, project.quota_set['network']['floatingip'], 'floating IPs', usage[:ip_quota_total]]
-        usage[:load_balancer_usage].each do |load_balancer|
-          csv << [project.name, "Load Balancer", nil, load_balancer[:lb_id], load_balancer[:name], load_balancer[:hours], "hours", load_balancer[:cost]]
+        usage[:load_balancers].each do |load_balancer|
+          csv << [project.name, "Load Balancer", nil, load_balancer[:id], load_balancer[:name], load_balancer[:hours], "hours", load_balancer[:cost]]
         end
-        usage[:vpn_connection_usage].each do |vpn_connection|
-          csv << [project.name, "VPN Connection", nil, vpn_connection[:vpn_connection_id], vpn_connection[:name], vpn_connection[:hours], "hours", vpn_connection[:cost]]
+        usage[:vpns].each do |vpn_connection|
+          csv << [project.name, "VPN Connection", nil, vpn_connection[:id], vpn_connection[:name], vpn_connection[:hours], "hours", vpn_connection[:cost]]
         end
       end
     end

--- a/app/lib/billing/ip_quotas.rb
+++ b/app/lib/billing/ip_quotas.rb
@@ -17,9 +17,56 @@ module Billing
       end
     end
 
-    def self.usage(project_id, from, to)
-      Billing::IpQuota.where(:recorded_at => from..to,
-                              :project_id => project_id).order('recorded_at')
+    def self.usage(project, from, to)      
+      changes = Billing::IpQuota.where(:recorded_at => from..to,
+                                       :project_id => project.uuid)
+                                .order('recorded_at')
+                                .map do |ipq|
+        {
+          previous:    ipq.previous,
+          quota:       ipq.quota,
+          recorded_at: ipq.recorded_at
+        }
+      end
+      ipqh = ip_quota_hours(project, changes, from, to)
+      {
+        current_quota: project.quota_set['network']['floatingip'].to_i,
+        quota_changes: changes,
+        usage: [
+          {
+            value: ipqh,
+            unit: 'hours',
+            cost: {
+              currency: 'gbp',
+              value: (ipqh * RateCard.ip_address).nearest_penny.round(2),
+              rate: RateCard.ip_address
+            }
+          }
+        ]
+      }
+    end
+
+    private
+
+    def self.ip_quota_hours(project, results, from, to)
+      results = results || []
+      if results.none?
+        quota = [project.quota_set['network']['floatingip'].to_i - 1, 0].max
+        return (((to - from) / 60.0) / 60.0).round * quota
+      else
+        start = from
+        hours = results.collect do |quota|
+          period = (((quota[:recorded_at] - start) / 60.0) / 60.0).round
+          start = quota[:recorded_at]
+          q = quota[:previous] ? quota[:previous] : 1
+          (q - 1) * period
+        end.sum
+
+        q = [(results.last[:quota] || 1) - 1, 0].max
+        period = (((to - results.last[:recorded_at]) / 60.0) / 60.0).round
+        hours += (q * period)
+        return hours
+      end
     end
 
   end

--- a/app/lib/billing/load_balancers.rb
+++ b/app/lib/billing/load_balancers.rb
@@ -31,13 +31,23 @@ module Billing
         finish = lb.terminated_at ? [lb.terminated_at, to].min : to
         hours = ((finish - start) / (60 ** 2)).ceil
         {
-          lb_id: lb.lb_id,
+          id: lb.lb_id,
           name:  lb.name,
           started_at: lb.started_at,
           terminated_at: lb.terminated_at,
-          hours: hours,
-          cost:  (hours * RateCard.lb_pool).nearest_penny,
-          owner: lb.user_id
+          owner: lb.user_id,
+          usage: [
+            {
+              unit: 'hours',
+              value: hours,
+              cost: {
+                currency: 'gbp',
+                value: (hours * RateCard.lb_pool).nearest_penny.round(2),
+                rate: RateCard.lb_pool
+              },
+              meta: {}
+            }
+          ]
         }
       end
     end

--- a/app/lib/billing/storage_objects.rb
+++ b/app/lib/billing/storage_objects.rb
@@ -25,7 +25,20 @@ module Billing
         last = measurement
         gb * seconds
       end.sum
-      gbs / 3_600_000.0
+      tbh = (gbs / 3_600_000.0)
+      {
+        usage: [
+          {
+            cost: {
+              currency: 'gbp',
+              rate: RateCard.object_storage,
+              value: (tbh * RateCard.object_storage).nearest_penny
+            },
+            unit: 'terabyte hours',
+            value: tbh.round(3)
+          }
+        ]
+      }
     end
 
   end

--- a/app/lib/billing/volumes.rb
+++ b/app/lib/billing/volumes.rb
@@ -14,163 +14,34 @@ module Billing
     def self.usage(project_id, from, to)
       volumes = Billing::Volume.where("project_id = ? AND (deleted_at is null or deleted_at >= ?)", project_id, from)
       volumes = volumes.collect do |volume|
+        cost_by_volume_type = volume.cost_by_volume_type(from, to)
+        volume_usage = volume.terabyte_hours(from, to).map do |volume_type, tbh|
+          {
+            unit: 'terabyte hours',
+            value: tbh.nearest_penny.round(2),
+            cost: {
+              currency: 'gbp',
+              value: cost_by_volume_type[volume_type].nearest_penny.round(2),
+              rate: volume.rate_for_volume_type(volume_type)
+            },
+            meta: {
+              volume_type: volume_name[volume_type]
+            }
+          }
+        end
         {
-          terabyte_hours: terabyte_hours(volume, from, to),
-          cost: cost(volume, from, to).nearest_penny,
           id: volume.volume_id,
           created_at: volume.created_at,
           deleted_at: volume.deleted_at,
-          latest_size: volume.latest_size,
+          latest_size_gb: volume.latest_size,
           name: volume.name,
-          ssd: volume.ssd?,
           tags: [
             volume.ssd? ? 'ssd' : nil,
           ].compact,
-          volume_type_name: volume_name[volume.volume_type],
-          owner: volume.volume_states&.first&.user_id
+          owner: volume.volume_states&.first&.user_id,
+          usage: volume_usage
         }
       end
-      volumes.select{|v| v[:terabyte_hours] > 0}
-    end
-
-    def self.terabyte_hours(volume, from, to)
-      states = volume.volume_states.where(:recorded_at => from..to).order('recorded_at')
-      previous_state = volume.volume_states.where('recorded_at < ?', from).order('recorded_at DESC').limit(1).first
-
-      if states.any?
-        if states.count > 1
-          start = 0
-
-          if previous_state
-            if billable?(previous_state.event_name)
-              start = seconds_to_whole_hours(states.first.recorded_at - from)
-              start *= gigabytes_to_terabytes(states.first.size)
-            end
-          end
-
-          previous = states.first
-          middle = states.collect do |state|
-            difference = 0
-            if billable?(previous.event_name)
-              difference = seconds_to_whole_hours(state.recorded_at - previous.recorded_at)
-              difference *= gigabytes_to_terabytes(state.size)
-            end
-            previous = state
-            difference
-          end.sum
-
-          ending = 0
-
-          if(billable?(states.last.event_name))
-            ending = seconds_to_whole_hours(to - states.last.recorded_at)
-            ending *= gigabytes_to_terabytes(states.last.size)
-          end
-
-          return (start + middle + ending).round(2)
-        else
-          # Only one sample for this period
-          if billable?(states.first.event_name)
-            return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(states.first.size)).round(2)
-          else
-            return 0
-          end
-        end
-      else
-        if previous_state && billable?(previous_state.event_name)
-          return (seconds_to_whole_hours(to - from) * gigabytes_to_terabytes(previous_state.size)).round(2)
-        else
-          return 0
-        end
-      end
-    end
-
-    def self.cost(volume, from, to)
-      volume_states = volume.volume_states.where(:recorded_at => from..to).order('recorded_at')
-      rate = volume.ssd? ? RateCard.ssd_storage : RateCard.block_storage
-      if volume_states.collect(&:volume_type).uniq.count > 1
-        return split_cost(volume, volume_states, from, to).nearest_penny
-      else
-        tb_hours = terabyte_hours(volume, from, to)
-        return (tb_hours * rate).nearest_penny
-      end
-    end
-
-    def self.split_cost(volume, states, from, to)
-      previous_state = volume.volume_states.where('recorded_at < ?', from).order('recorded_at DESC').limit(1).first
-      first_state = states.first
-      last_state = states.last
-
-      if states.any?
-        if states.count > 1
-          start = 0
-
-          if previous_state
-            if billable?(previous_state.event_name)
-              start = (first_state.recorded_at - from)
-              start = start / Billing::SECONDS_TO_HOURS
-              base = start * previous_state.rate
-              start = base
-            end
-          end
-
-          previous = states.first
-          middle = states.collect do |state|
-            difference = 0
-            if billable?(previous.event_name)
-              difference = state.recorded_at - previous.recorded_at
-            end
-            begin
-              difference = difference / Billing::SECONDS_TO_HOURS
-              base = difference * previous.rate
-              base
-            ensure
-              previous = state
-            end
-          end.sum
-
-          ending = 0
-
-          if(billable?(last_state.event_name))
-            ending = (to - last_state.recorded_at)
-            ending = ending / Billing::SECONDS_TO_HOURS
-            base = ending * last_state.rate
-            ending = base
-          end
-
-          return (start + middle + ending)
-        else
-          # Only one sample for this period
-          if billable?(first_state.event_name)
-            time = (to - first_state.recorded_at)
-            time = time / Billing::SECONDS_TO_HOURS
-            base = time * first_state.rate
-            return base
-          else
-            return 0
-          end
-        end
-      else
-        if previous_state && billable?(previous_state.event_name)
-          time = (to - from)
-          time = time / Billing::SECONDS_TO_HOURS
-          base = time * previous_state.rate
-          return base
-        else
-          return 0
-        end
-      end
-    end
-
-    def self.billable?(event)
-      event != 'volume.delete.end'
-    end
-
-    def self.seconds_to_whole_hours(seconds)
-      (seconds / Billing::SECONDS_TO_HOURS).ceil
-    end
-
-    def self.gigabytes_to_terabytes(gigabytes)
-      (gigabytes / 1024.0).round(2)
     end
 
     def self.volume_name
@@ -191,19 +62,12 @@ module Billing
 
     def self.create_new_states(project_id, volume_id, samples, sync)
       first_sample_metadata = samples.first['resource_metadata']
+      billing_volume = Billing::Volume.find_by_volume_id(volume_id)
       unless cached_volumes.keys.include?(volume_id)
         Rails.cache.delete('all_recorded_volume_ids')
-        volume = Billing::Volume.create(volume_id: volume_id, project_id: project_id,
-                                        name: first_sample_metadata["display_name"])
-        unless samples.any? {|s| s['resource_metadata']['event_type']}
-          # This is a new volume and we don't know its current size
-          # Attempt to find out
-          if(os_volume = OpenStackConnection.volume.volumes.get(volume_id))
-            volume.volume_states.create recorded_at: Time.now, size: os_volume.size,
-                                            event_name: 'ping', billing_sync: sync,
-                                            message_id: SecureRandom.uuid,
-                                            volume_type: volume_name.key(os_volume.volume_type)
-          end
+        billing_volume = Billing::Volume.find_or_create_by(volume_id: volume_id) do |volume|
+          volume.project_id = project_id
+          volume.name       = first_sample_metadata["display_name"]
         end
       end
 
@@ -231,7 +95,7 @@ module Billing
                                       user_id: s['user_id']
         end
       end
+      billing_volume.reindex_states
     end
-
   end
 end

--- a/app/lib/billing/vpn_connections.rb
+++ b/app/lib/billing/vpn_connections.rb
@@ -31,13 +31,23 @@ module Billing
         finish = vpn.terminated_at ? [vpn.terminated_at, to].min : to
         hours = ((finish - start) / (60 ** 2)).ceil
         {
-          vpn_connection_id: vpn.vpn_connection_id,
+          id: vpn.vpn_connection_id,
           name:  vpn.name,
           started_at: vpn.started_at,
           terminated_at: vpn.terminated_at,
-          hours: hours,
-          cost:  (hours * RateCard.vpn_connection).nearest_penny,
-          owner: vpn.user_id
+          owner: vpn.user_id,
+          usage: [
+            {
+              unit: 'hours',
+              value: hours,
+              cost: {
+                currency: 'gbp',
+                value: (hours * RateCard.vpn_connection).nearest_penny.round(2),
+                rate: RateCard.vpn_connection
+              },
+              meta: {}
+            }
+          ]
         }
       end
     end

--- a/app/models/billing/instance_state.rb
+++ b/app/models/billing/instance_state.rb
@@ -20,10 +20,6 @@ module Billing
       next_state.nil?
     end
 
-    def only_state?
-      first_state? && last_state?
-    end
-
     def next_state
       InstanceState.find_by_id(next_state_id) if next_state_id
     end
@@ -48,7 +44,7 @@ module Billing
       {
         billable:    billable?,
         flavor:      instance_flavor.flavor_id,
-        seconds:     seconds(from, to),
+        seconds:     seconds(from, to).ceil,
         state:       state,
         user_id:     user_id,
         recorded_at: recorded_at

--- a/app/models/billing/usage.rb
+++ b/app/models/billing/usage.rb
@@ -25,14 +25,15 @@ module Billing
 
     def blob
       conn
-      Marshal.load(
+      JSON.parse(
         open(
           AWS::S3::S3Object.url_for(
             object_uuid,
             bucket,
             authenticated: true
           )
-        )
+        ).read,
+        symbolize_names: true
       )
     rescue OpenURI::HTTPError => ex
       raise unless ex.message.include?("404")
@@ -43,9 +44,9 @@ module Billing
       conn
       AWS::S3::S3Object.store(
         object_uuid,
-        Marshal.dump(new_blob),
+        new_blob.to_json,
         bucket,
-        content_type: 'application/octet-stream'
+        content_type: 'application/json'
       )
     end
 

--- a/app/models/billing/volume.rb
+++ b/app/models/billing/volume.rb
@@ -13,6 +13,15 @@ module Billing
       latest_state ? Billing::Volumes.billable?(latest_state.event_name) : true
     end
 
+    def reindex_states
+      volume_states.each_cons(2) do |first, second|
+        first.update_column(:next_state_id, second.id)
+        second.update_column(:previous_state_id, first.id)
+      end
+      volume_states&.first&.update_column(:previous_state_id, nil)
+      volume_states&.last&.update_column(:next_state_id, nil)
+    end
+
     def created_at
       volume_states.where(event_name: 'volume.create.end').order('recorded_at').first.try(:recorded_at) { nil }
     end
@@ -23,6 +32,73 @@ module Billing
       deleted_at = volume_states.where(event_name: 'volume.delete.end').order('recorded_at').first.try(:recorded_at) { nil }
       update_attributes deleted_at: deleted_at
       deleted_at
+    end
+
+    def fetch_states(from, to)
+      states = volume_states.where(:recorded_at => from..to)
+      if states.any?
+        # Sometimes states arrive out of order and the final state by timestamp
+        # isn't actually the final state. This can make volumes appear to be
+        # active, even after they're deleted.
+        if states.collect(&:event_name).include?('volume.delete.end')
+          found_deleted = false
+          return states.take_while do |state| 
+            begin
+              !found_deleted
+            ensure
+              found_deleted = true if state.event_name == 'volume.delete.end'
+            end
+          end
+        end
+      end
+      states
+    end
+
+    def history(from, to)
+      history = fetch_states(from, to).to_a
+      history.unshift(history.first.previous_state) if history&.first&.previous_state
+      history = history.map do |state|
+        state.to_hash(from, to)
+      end
+      return history if history.count > 0
+      latest_state = volume_states.where("recorded_at < ?", from).last
+
+      if latest_state && from >= latest_state.recorded_at
+        return [latest_state.to_hash(from, to)] if latest_state&.billable?
+      end
+      []
+    end
+
+    def billable_history(from, to)
+      history(from, to).select{|i| i[:billable]}
+    end
+
+    def terabyte_hours(from, to)
+      Hash[billable_history(from, to).group_by{|i| i[:volume_type]}.map {|volume_type, volume_states|
+        tbh = volume_states.sum{|i| (i[:seconds] / Billing::SECONDS_TO_HOURS) * (i[:size] / 1024.0)}
+        [volume_type, tbh]
+      }]
+    end
+
+    def cost_by_volume_type(from, to)
+      Hash[
+        terabyte_hours(from, to).map do |volume_type, hours|
+          price = rate_for_volume_type(volume_type)
+          [volume_type, price * hours]
+        end
+      ]
+    end
+
+    def rate_for_volume_type(volume_type)
+      if Billing::Volumes.volume_name[volume_type].downcase.include?('ssd')
+        RateCard.ssd_storage
+      else
+        RateCard.block_storage
+      end
+    end
+
+    def cost(from, to)
+      cost_by_volume_type(from, to).sum {|_,c| c}
     end
 
     def latest_state

--- a/app/views/admin/usage/report.html.haml
+++ b/app/views/admin/usage/report.html.haml
@@ -10,20 +10,17 @@
     %strong Total:
     == £#{number_with_precision(@grand_total, :delimiter => ',', :separator => '.', :precision => 2)}
 
-  - @usage.each do |project, results|
+  - @usage[:projects].each do |project|
     %hr
     %h2
       %strong Project:
-      = project.name
+      = project[:name]
 
-    = render partial: 'admin/usage/results/vouchers',  locals: { vouchers: @active_vouchers }
-    = render partial: 'admin/usage/results/instances', locals: { project: project, instances:        results[:instance_usage]            }
-    = render partial: 'admin/usage/results/volumes',   locals: { project: project, volumes:           results[:volume_usage]              }
-    = render partial: 'admin/usage/results/images',    locals: { project: project, images:            results[:image_usage]             }
-    = render partial: 'admin/usage/results/objects',   locals: { project: project, tbh:               results[:object_storage_usage]   }
-    = render partial: 'admin/usage/results/ips',       locals: { ip_quotas:         results[:ip_quota_usage],
-                                                                 ip_quota_total:    results[:ip_quota_total],
-                                                                 external_gateways: @external_gateway_results,
-                                                                 project:           project                     }
-    = render partial: 'admin/usage/results/load_balancers',      locals: { load_balancers:  results[:load_balancer_usage], project: project }
-    = render partial: 'admin/usage/results/vpn_connections',     locals: { vpn_connections: results[:vpn_connection_usage], project: project }
+    = render partial: 'admin/usage/results/vouchers',        locals: { vouchers:     @active_vouchers                                                }
+    = render partial: 'admin/usage/results/instances',       locals: { project_uuid: project[:id], instances:         project[:usage][:instances]    }
+    = render partial: 'admin/usage/results/volumes',         locals: { project_uuid: project[:id], volumes:           project[:usage][:volumes]      }
+    = render partial: 'admin/usage/results/images',          locals: { project_uuid: project[:id], images:            project[:usage][:images]       }
+    = render partial: 'admin/usage/results/objects',         locals: { tbh:          project[:usage][:object_storage][:usage].sum{|u| u[:value]}     }
+    = render partial: 'admin/usage/results/ips',             locals: { ips:          project[:usage][:ips]                                           }
+    = render partial: 'admin/usage/results/load_balancers',  locals: { project_uuid: project[:id], load_balancers:  project[:usage][:load_balancers] }
+    = render partial: 'admin/usage/results/vpn_connections', locals: { project_uuid: project[:id], vpn_connections: project[:usage][:vpns]           }

--- a/app/views/admin/usage/results/_images.html.haml
+++ b/app/views/admin/usage/results/_images.html.haml
@@ -27,14 +27,14 @@
               %td= image[:id]
               %td= image[:created_at]
               %td
-                = image[:latest_size].round(2)
+                = image[:latest_size_gb].round(2)
                 GB
               %td= image[:deleted_at] ? image[:deleted_at] : '-'
               %td
-                = number_with_delimiter(image[:terabyte_hours], :delimiter => ',')
+                = number_with_delimiter(image[:usage].sum{|u| u[:value]}, :delimiter => ',')
                 TBh
               - if current_organization.show_costs?
-                %td== £#{number_with_precision(image[:cost], :delimiter => ',', :separator => '.', :precision => 4)}
+                %td== £#{number_with_precision(image[:usage].sum{|u| u[:cost][:value]}, :delimiter => ',', :separator => '.', :precision => 2)}
           %tr.highlight.bottomline
             %td &nbsp;
             %td &nbsp
@@ -43,9 +43,9 @@
             %td &nbsp
             %td Total:
             %td
-              = number_with_delimiter(images.collect{|v| v[:terabyte_hours]}.sum.round(2), :delimiter => ',')
+              = number_with_delimiter(images.sum{|i| i[:usage].sum{|u| u[:value]}}.round(2), :delimiter => ',')
               TBh
             - if current_organization.show_costs?
               %td
-                == £#{number_with_precision(@usage_decorator.image_total(project.id), :delimiter => ',', :separator => '.', :precision => 2)}
+                == £#{number_with_precision(@usage_decorator.image_total(project_uuid), :delimiter => ',', :separator => '.', :precision => 2)}
 

--- a/app/views/admin/usage/results/_instances.html.haml
+++ b/app/views/admin/usage/results/_instances.html.haml
@@ -4,11 +4,11 @@
     .table-responsive
       %table.table.table-hover.phone-bill
         %tbody
-          - instances.group_by{|i| i[:flavor][:flavor_id]}.each do |flavor_id, instances|
+          - instances.group_by{|i| i[:current_flavor][:id]}.each do |flavor_id, instances|
             %tr.highlight
               %td.icon
                 %i.fa.fa-rocket
-              %td== Flavor: #{instances.first[:flavor][:name]}
+              %td== Flavor: #{instances.first[:current_flavor][:name]}
               %td Unique Identifier
               %td First Booted
               %td Status
@@ -28,32 +28,32 @@
               %td.line_entry
               - if current_organization.show_costs?
                 %td.line_entry
-            - instances.sort { |x,y| x[:name] <=> y[:name] }.each do |instance|
+            - instances.sort_by{|i| i[:name]}.each do |instance|
               %tr
                 %td.line_entry
-                  - if instance[:windows]
+                  - if instance[:tags].include? 'windows'
                     %i.fa.fa-windows{title: 'Windows Instance †'}
                   &nbsp;
                 %td.line_entry= instance[:name]
-                %td.line_entry= instance[:uuid]
+                %td.line_entry= instance[:id]
                 %td.line_entry= instance[:first_booted_at]
                 %td.line_entry= state_with_icon(instance[:latest_state])
                 %td.line_entry= (instance[:terminated_at] && instance[:terminated_at] <= @to_date) ? instance[:terminated_at] : '-'
                 %td.line_entry
                   %i.fa.fa-clock-o
-                  == #{number_with_delimiter(instance[:total_hours], :delimiter => ',')} of #{@total_hours}
+                  == #{number_with_delimiter(instance[:usage].sum{|u| u[:value]}, :delimiter => ',')} of #{@total_hours}
                 - if current_organization.show_costs?
-                  %td.line_entry== £#{number_with_precision(instance[:cost], :delimiter => ',', :separator => '.', :precision => 4)}
+                  %td.line_entry== £#{number_with_precision(instance[:usage].sum{|u| u[:cost][:value]}, :delimiter => ',', :separator => '.', :precision => 2)}
             %tr.highlight.bottomline
               %td &nbsp;
               %td &nbsp;
               %td &nbsp;
               %td &nbsp;
               %td &nbsp;
-              %td== Total #{instances.first[:flavor][:name]}:
-              %td== #{number_with_delimiter(instances.map{|i| i[:total_hours]}.sum, :delimiter => ',')} hours
+              %td== Total #{instances.first[:current_flavor][:name]}:
+              %td== #{number_with_delimiter(instances.sum{|i| i[:usage].sum{|u| u[:value]}}, :delimiter => ',')} hours
               - if current_organization.show_costs?
-                %td== £#{number_with_precision(@usage_decorator.instance_total(project.id, flavor_id), :delimiter => ',', :separator => '.', :precision => 2)}
+                %td== £#{number_with_precision(@usage_decorator.instance_total(project_uuid, flavor_id), :delimiter => ',', :separator => '.', :precision => 2)}
             %tr
               %td &nbsp;
               %td &nbsp;

--- a/app/views/admin/usage/results/_ips.html.haml
+++ b/app/views/admin/usage/results/_ips.html.haml
@@ -3,12 +3,12 @@
   %p.tiny One address included free of charge.
   %p
     %strong Current Quota:
-    == #{project.quota_set['network']['floatingip']} addresses
+    == #{ips[:current_quota]} addresses
   - if current_organization.show_costs?
     %p
       %strong Cost:
-      == £#{number_with_precision(ip_quota_total, :delimiter => ',', :separator => '.', :precision => 2)}
-  - if ip_quotas && ip_quotas.any?
+      == £#{number_with_precision(ips[:usage].sum{|u| u[:cost][:value]}, :delimiter => ',', :separator => '.', :precision => 2)}
+  - if ips[:quota_changes] && ips[:quota_changes].any?
     .table-responsive
       %table.table.table-hover.phone-bill
         %thead
@@ -20,14 +20,14 @@
             %th Previous Value
             
         %tbody
-          - ip_quotas.each do |quota|
+          - ips[:quota_changes].each do |quota|
             %tr
               %td &nbsp;
-              %td= quota.recorded_at
+              %td= quota[:recorded_at]
               %td
-                = quota.quota
+                = quota[:quota]
                 addresses
               %td
-                = quota.previous.nil? ? "-" : "#{quota.previous} addresses"
+                = quota[:previous].nil? ? "-" : "#{quota[:previous]} addresses"
 
 

--- a/app/views/admin/usage/results/_load_balancers.html.haml
+++ b/app/views/admin/usage/results/_load_balancers.html.haml
@@ -23,13 +23,13 @@
             %tr
               %td &nbsp;
               %td= lb[:name]
-              %td= lb[:lb_id]
+              %td= lb[:id]
               %td= lb[:started_at]
               %td= lb[:terminated_at] ? lb[:terminated_at] : '-'
               %td
-                == #{number_with_delimiter(lb[:hours], :delimiter => ',')} of #{@total_hours}
+                == #{number_with_delimiter(lb[:usage].sum{|u| u[:value]}, :delimiter => ',')} of #{@total_hours}
               - if current_organization.show_costs?
-                %td== £#{number_with_precision(lb[:cost], :delimiter => ',', :separator => '.', :precision => 4)}
+                %td== £#{number_with_precision(lb[:usage].sum{|u| u[:cost][:value]}, :delimiter => ',', :separator => '.', :precision => 2)}
           %tr.highlight.bottomline
             %td &nbsp
             %td &nbsp
@@ -37,9 +37,9 @@
             %td &nbsp;
             %td Total:
             %td
-              = number_with_delimiter(load_balancers.collect{|v| v[:hours]}.sum, :delimiter => ',')
+              = number_with_delimiter(load_balancers.sum{|lb| lb[:usage].sum{|u| u[:value]}}, :delimiter => ',')
               hours
             - if current_organization.show_costs?
               %td
-                == £#{number_with_precision(@usage_decorator.load_balancer_total(project.id), :delimiter => ',', :separator => '.', :precision => 2)}
+                == £#{number_with_precision(@usage_decorator.load_balancer_total(project_uuid), :delimiter => ',', :separator => '.', :precision => 2)}
 

--- a/app/views/admin/usage/results/_volumes.html.haml
+++ b/app/views/admin/usage/results/_volumes.html.haml
@@ -28,15 +28,15 @@
               %td= volume[:id]
               %td= volume[:created_at]
               %td
-                = volume[:latest_size]
+                = volume[:latest_size_gb]
                 GB
               %td= volume[:deleted_at] ? volume[:deleted_at] : '-'
-              %td= volume[:volume_type_name] ? volume[:volume_type_name]  : '-'
+              %td= volume[:tags].include?('ssd') ? 'SSD'  : '-'
               %td
-                = number_with_delimiter(volume[:terabyte_hours], :delimiter => ',')
+                = number_with_delimiter(volume[:usage].sum{|u| u[:value]}.round(4), :delimiter => ',')
                 TBh
               - if current_organization.show_costs?
-                %td== £#{number_with_precision(volume[:cost], :delimiter => ',', :separator => '.', :precision => 4)}
+                %td== £#{number_with_precision(volume[:usage].sum{|u| u[:cost][:value]}.nearest_penny, :delimiter => ',', :separator => '.', :precision => 2)}
           %tr.highlight.bottomline
             %td &nbsp
             %td &nbsp
@@ -46,9 +46,9 @@
             %td &nbsp;
             %td Total:
             %td
-              = number_with_delimiter(volumes.collect{|v| v[:terabyte_hours]}.sum.round(2), :delimiter => ',')
+              = number_with_delimiter(volumes.sum{|i| i[:usage].sum{|u| u[:value]}}.round(2), :delimiter => ',')
               TBh
             - if current_organization.show_costs?
               %td
-                == £#{number_with_precision(@usage_decorator.volume_total(project.id), :delimiter => ',', :separator => '.', :precision => 2)}
+                == £#{number_with_precision(@usage_decorator.volume_total(project_uuid), :delimiter => ',', :separator => '.', :precision => 2)}
 

--- a/app/views/admin/usage/results/_vpn_connections.html.haml
+++ b/app/views/admin/usage/results/_vpn_connections.html.haml
@@ -23,13 +23,13 @@
             %tr
               %td &nbsp;
               %td= vpn[:name]
-              %td= vpn[:vpn_connection_id]
+              %td= vpn[:id]
               %td= vpn[:started_at]
               %td= vpn[:terminated_at] ? vpn[:terminated_at] : '-'
               %td
-                == #{number_with_delimiter(vpn[:hours], :delimiter => ',')} of #{@total_hours}
+                == #{number_with_delimiter(vpn[:usage].sum{|u| u[:value]}, :delimiter => ',')} of #{@total_hours}
               - if current_organization.show_costs?
-                %td== £#{number_with_precision(vpn[:cost], :delimiter => ',', :separator => '.', :precision => 4)}
+                %td== £#{number_with_precision(vpn[:usage].sum{|u| u[:cost][:value]}, :delimiter => ',', :separator => '.', :precision => 2)}
           %tr.highlight.bottomline
             %td &nbsp
             %td &nbsp
@@ -37,9 +37,9 @@
             %td &nbsp;
             %td Total:
             %td
-              = number_with_delimiter(vpn_connections.collect{|v| v[:hours]}.sum, :delimiter => ',')
+              = number_with_delimiter(vpn_connections.sum{|lb| lb[:usage].sum{|u| u[:value]}}, :delimiter => ',')
               hours
             - if current_organization.show_costs?
               %td
-                == £#{number_with_precision(@usage_decorator.vpn_connection_total(project.id), :delimiter => ',', :separator => '.', :precision => 2)}
+                == £#{number_with_precision(@usage_decorator.vpn_connection_total(project_uuid), :delimiter => ',', :separator => '.', :precision => 2)}
 

--- a/app/views/support/usage/index.html.haml
+++ b/app/views/support/usage/index.html.haml
@@ -19,22 +19,20 @@
     %p.tiny= link_to 'View Pricing', 'http://www.datacentred.co.uk/pricing/', target: '_blank'
 
 - if @usage.any?
-  - @usage.each do |project, results|
+  - @usage[:projects].each do |project|
     %h2
       %i.fa.fa-folder-o
-      = project.name
+      = project[:name]
 
-    = render partial: 'admin/usage/results/vouchers',  locals: { vouchers: @active_vouchers }
-    = render partial: 'admin/usage/results/instances', locals: { project: project, instances:         results[:instance_usage]         }
-    = render partial: 'admin/usage/results/volumes',   locals: { project: project, volumes:           results[:volume_usage]           }
-    = render partial: 'admin/usage/results/images',    locals: { project: project, images:            results[:image_usage]            }
-    = render partial: 'admin/usage/results/objects',   locals: { project: project, tbh:               results[:object_storage_usage]   }
-    = render partial: 'admin/usage/results/ips',       locals: { project: project, ip_quotas:         results[:ip_quota_usage],
-                                                                 ip_quota_total:                      results[:ip_quota_total],
-                                                                 external_gateways: results[:external_gateway_results]}
-    = render partial: 'admin/usage/results/load_balancers',  locals: { project: project, load_balancers: results[:load_balancer_usage]}
-    = render partial: 'admin/usage/results/vpn_connections', locals: { project: project, vpn_connections: results[:vpn_connection_usage]}
-- else
+    = render partial: 'admin/usage/results/vouchers',        locals: { vouchers:     @active_vouchers                                                }
+    = render partial: 'admin/usage/results/instances',       locals: { project_uuid: project[:id], instances:         project[:usage][:instances]    }
+    = render partial: 'admin/usage/results/volumes',         locals: { project_uuid: project[:id], volumes:           project[:usage][:volumes]      }
+    = render partial: 'admin/usage/results/images',          locals: { project_uuid: project[:id], images:            project[:usage][:images]       }
+    = render partial: 'admin/usage/results/objects',         locals: { tbh:          project[:usage][:object_storage][:usage].sum{|u| u[:value]}     }
+    = render partial: 'admin/usage/results/ips',             locals: { ips:          project[:usage][:ips]                                           }
+    = render partial: 'admin/usage/results/load_balancers',  locals: { project_uuid: project[:id], load_balancers:  project[:usage][:load_balancers] }
+    = render partial: 'admin/usage/results/vpn_connections', locals: { project_uuid: project[:id], vpn_connections: project[:usage][:vpns]           }
+
   %h3
     %em No usage data collected yet.
 

--- a/db/migrate/20170705084827_add_navigable_volume_event_columns.rb
+++ b/db/migrate/20170705084827_add_navigable_volume_event_columns.rb
@@ -1,0 +1,9 @@
+class AddNavigableVolumeEventColumns < ActiveRecord::Migration[5.0]
+  def change
+    add_column :billing_volume_states, :previous_state_id, :integer
+    add_column :billing_volume_states, :next_state_id,     :integer
+
+    add_index :billing_volume_states, :previous_state_id
+    add_index :billing_volume_states, :next_state_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170605091157) do
+ActiveRecord::Schema.define(version: 20170705084827) do
 
   create_table "api_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -196,7 +196,7 @@ ActiveRecord::Schema.define(version: 20170605091157) do
   end
 
   create_table "billing_volume_states", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.datetime "recorded_at", precision: 3
+    t.datetime "recorded_at",       precision: 3
     t.string   "event_name"
     t.integer  "size"
     t.integer  "volume_id"
@@ -204,6 +204,10 @@ ActiveRecord::Schema.define(version: 20170605091157) do
     t.integer  "sync_id"
     t.string   "volume_type"
     t.string   "user_id"
+    t.integer  "previous_state_id"
+    t.integer  "next_state_id"
+    t.index ["next_state_id"], name: "index_billing_volume_states_on_next_state_id", using: :btree
+    t.index ["previous_state_id"], name: "index_billing_volume_states_on_previous_state_id", using: :btree
     t.index ["recorded_at"], name: "index_billing_volume_states_on_recorded_at", using: :btree
     t.index ["sync_id"], name: "volume_syncs", using: :btree
     t.index ["volume_id"], name: "volume_states", using: :btree
@@ -300,12 +304,12 @@ ActiveRecord::Schema.define(version: 20170605091157) do
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "time_zone",                        default: "London", null: false
-    t.string   "locale",                           default: "en",     null: false
+    t.string   "time_zone",                                    default: "London",              null: false
+    t.string   "locale",                                       default: "en",                  null: false
     t.integer  "primary_project_id"
     t.datetime "started_paying_at"
     t.string   "stripe_customer_id"
-    t.boolean  "self_service",                     default: true,     null: false
+    t.boolean  "self_service",                                 default: true,                  null: false
     t.string   "salesforce_id"
     t.string   "billing_address1"
     t.string   "billing_address2"
@@ -314,20 +318,19 @@ ActiveRecord::Schema.define(version: 20170605091157) do
     t.string   "billing_country"
     t.string   "phone"
     t.integer  "customer_signup_id"
-    t.string   "state",                            default: "active", null: false
-    t.boolean  "disabled",                         default: false,    null: false
-    t.boolean  "test_account",                     default: false,    null: false
+    t.string   "state",                                        default: "active",              null: false
+    t.boolean  "disabled",                                     default: false,                 null: false
+    t.boolean  "test_account",                                 default: false,                 null: false
     t.string   "reporting_code"
-    t.boolean  "limited_storage",                  default: false,    null: false
-    t.integer  "projects_limit",                   default: 1,        null: false
-    t.float    "weekly_spend",       limit: 24,    default: 0.0,      null: false
-    t.text     "quota_limit",        limit: 65535
+    t.boolean  "limited_storage",                              default: false,                 null: false
+    t.integer  "projects_limit",                               default: 1,                     null: false
+    t.float    "weekly_spend",                   limit: 24,    default: 0.0,                   null: false
+    t.text     "quota_limit",                    limit: 65535
     t.string   "billing_contact"
-    t.boolean  "bill_automatically",               default: true,     null: false
+    t.boolean  "bill_automatically",                           default: true,                  null: false
     t.string   "technical_contact"
-    t.boolean  "slow_jobs",                        default: false,    null: false
-    t.boolean  "track_usage",                      default: true,     null: false
-    t.datetime "last_alerted_for_low_quotas_at"
+    t.boolean  "slow_jobs",                                    default: false,                 null: false
+    t.boolean  "track_usage",                                  default: true,                  null: false
     t.datetime "last_alerted_for_low_quotas_at",               default: '1970-01-01 01:00:00'
     t.index ["reporting_code"], name: "index_organizations_on_reporting_code", unique: true, using: :btree
     t.index ["state"], name: "index_organizations_on_state", using: :btree

--- a/fixtures/vcr_cassettes/usage_blob_syncs_to_ceph.yml
+++ b/fixtures/vcr_cassettes/usage_blob_syncs_to_ceph.yml
@@ -4,11 +4,11 @@ http_interactions:
     method: put
     uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386
     body:
-      encoding: ASCII-8BIT
-      string: "\x04\b{\x06:\fcomplexU:\x0FOpenStruct{\x06:\bfooI\"\bbar\x06:\x06ET"
+      encoding: UTF-8
+      string: '{"complex":{"foo":"bar"}}'
     headers:
       Content-Type:
-      - application/octet-stream
+      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -16,26 +16,26 @@ http_interactions:
       User-Agent:
       - Ruby
       Date:
-      - Wed, 07 Dec 2016 09:37:00 GMT
+      - Tue, 13 Jun 2017 11:59:06 GMT
       Authorization:
-      - AWS I9860H3V0MMNO5B3FQSX:i2XUWRO0Qh70lirE2dXbASb3pFg=
+      - AWS I9860H3V0MMNO5B3FQSX:3CAXIsuXKEmYc/lZxtOkmWQhnXc=
       Content-Length:
-      - '44'
+      - '25'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:06 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Etag:
-      - '"47c943f59600069ee4b826c1eaf204b3"'
+      - '"c94cf98f6e1072a4d996eefc70c765cc"'
       Accept-Ranges:
       - bytes
       X-Amz-Request-Id:
-      - tx000000000000000426efd-005847d837-899badb-uk-sal01
+      - tx00000000000000005c6a9-00593fd38a-e6a31a3-uk-sal01
       Content-Length:
       - '0'
       Strict-Transport-Security:
@@ -44,10 +44,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:06 GMT
 - request:
     method: get
-    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1481103720&Signature=74yP/oN90V28Ry0XzOCSDc0ZIIE=
+    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1497355447&Signature=cJ2lXQ8HJKtfodx5EVMS4VXRlzE=
     body:
       encoding: US-ASCII
       string: ''
@@ -64,31 +64,33 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:06 GMT
       Etag:
-      - '"47c943f59600069ee4b826c1eaf204b3"'
+      - '"c94cf98f6e1072a4d996eefc70c765cc"'
       X-Amz-Request-Id:
-      - tx000000000000000426f56-005847d837-8949e01-uk-sal01
-      Content-Length:
-      - '44'
+      - tx00000000000000005c667-00593fd38b-e1c7939-uk-sal01
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/octet-stream
+      - application/json
       Strict-Transport-Security:
       - max-age=31536000
     body:
-      encoding: UTF-8
-      string: "\x04\b{\x06:\fcomplexU:\x0FOpenStruct{\x06:\bfooI\"\bbar\x06:\x06ET"
+      encoding: ASCII-8BIT
+      string: '{"complex":{"foo":"bar"}}'
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:07 GMT
 - request:
     method: get
-    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1481103720&Signature=74yP/oN90V28Ry0XzOCSDc0ZIIE=
+    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1497355447&Signature=cJ2lXQ8HJKtfodx5EVMS4VXRlzE=
     body:
       encoding: US-ASCII
       string: ''
@@ -105,37 +107,39 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:06 GMT
       Etag:
-      - '"47c943f59600069ee4b826c1eaf204b3"'
+      - '"c94cf98f6e1072a4d996eefc70c765cc"'
       X-Amz-Request-Id:
-      - tx000000000000000426efe-005847d837-899badb-uk-sal01
-      Content-Length:
-      - '44'
+      - tx00000000000000005c6aa-00593fd38b-e6a31a3-uk-sal01
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/octet-stream
+      - application/json
       Strict-Transport-Security:
       - max-age=31536000
     body:
-      encoding: UTF-8
-      string: "\x04\b{\x06:\fcomplexU:\x0FOpenStruct{\x06:\bfooI\"\bbar\x06:\x06ET"
+      encoding: ASCII-8BIT
+      string: '{"complex":{"foo":"bar"}}'
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:07 GMT
 - request:
     method: put
     uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386
     body:
-      encoding: ASCII-8BIT
-      string: "\x04\b{\x06:\x0EsomethingI\"\telse\x06:\x06ET"
+      encoding: UTF-8
+      string: '{"something":"else"}'
     headers:
       Content-Type:
-      - application/octet-stream
+      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -143,26 +147,26 @@ http_interactions:
       User-Agent:
       - Ruby
       Date:
-      - Wed, 07 Dec 2016 09:37:00 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Authorization:
-      - AWS I9860H3V0MMNO5B3FQSX:i2XUWRO0Qh70lirE2dXbASb3pFg=
+      - AWS I9860H3V0MMNO5B3FQSX:0ZItAHbOfjKnuUOsfSjV0A13ycg=
       Content-Length:
-      - '27'
+      - '20'
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Etag:
-      - '"2d0a637a675b4fc8bead36af29481ea6"'
+      - '"1521cb63d9db1054200045580ee5422a"'
       Accept-Ranges:
       - bytes
       X-Amz-Request-Id:
-      - tx000000000000000426f57-005847d837-8949e01-uk-sal01
+      - tx00000000000000005c668-00593fd38b-e1c7939-uk-sal01
       Content-Length:
       - '0'
       Strict-Transport-Security:
@@ -171,10 +175,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:08 GMT
 - request:
     method: get
-    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1481103720&Signature=74yP/oN90V28Ry0XzOCSDc0ZIIE=
+    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1497355448&Signature=42lbSs4Cf1TUTAy1/8bemmA4TCE=
     body:
       encoding: US-ASCII
       string: ''
@@ -191,31 +195,33 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:56 GMT
+      - Tue, 13 Jun 2017 11:59:08 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Etag:
-      - '"2d0a637a675b4fc8bead36af29481ea6"'
+      - '"1521cb63d9db1054200045580ee5422a"'
       X-Amz-Request-Id:
-      - tx000000000000000426eff-005847d838-899badb-uk-sal01
-      Content-Length:
-      - '27'
+      - tx00000000000000005c669-00593fd38c-e1c7939-uk-sal01
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/octet-stream
+      - application/json
       Strict-Transport-Security:
       - max-age=31536000
     body:
-      encoding: UTF-8
-      string: "\x04\b{\x06:\x0EsomethingI\"\telse\x06:\x06ET"
+      encoding: ASCII-8BIT
+      string: '{"something":"else"}'
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:08 GMT
 - request:
     method: get
-    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1481103720&Signature=74yP/oN90V28Ry0XzOCSDc0ZIIE=
+    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1497355448&Signature=42lbSs4Cf1TUTAy1/8bemmA4TCE=
     body:
       encoding: US-ASCII
       string: ''
@@ -232,28 +238,30 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:56 GMT
+      - Tue, 13 Jun 2017 11:59:08 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Accept-Ranges:
       - bytes
       Last-Modified:
-      - Wed, 07 Dec 2016 09:36:55 GMT
+      - Tue, 13 Jun 2017 11:59:07 GMT
       Etag:
-      - '"2d0a637a675b4fc8bead36af29481ea6"'
+      - '"1521cb63d9db1054200045580ee5422a"'
       X-Amz-Request-Id:
-      - tx000000000000000426f00-005847d838-899badb-uk-sal01
-      Content-Length:
-      - '27'
+      - tx00000000000000005c6ac-00593fd38c-e6a31a3-uk-sal01
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
       Content-Type:
-      - application/octet-stream
+      - application/json
       Strict-Transport-Security:
       - max-age=31536000
     body:
-      encoding: UTF-8
-      string: "\x04\b{\x06:\x0EsomethingI\"\telse\x06:\x06ET"
+      encoding: ASCII-8BIT
+      string: '{"something":"else"}'
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:08 GMT
 - request:
     method: delete
     uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386
@@ -270,9 +278,9 @@ http_interactions:
       Content-Type:
       - binary/octet-stream
       Date:
-      - Wed, 07 Dec 2016 09:37:00 GMT
+      - Tue, 13 Jun 2017 11:59:08 GMT
       Authorization:
-      - AWS I9860H3V0MMNO5B3FQSX:sFwTJq3gSep7V688EWMb1F/JVwM=
+      - AWS I9860H3V0MMNO5B3FQSX:wvwVp8/OJu9xwhIW7fQSgVC5ybw=
       Content-Length:
       - '0'
   response:
@@ -281,21 +289,21 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:56 GMT
+      - Tue, 13 Jun 2017 11:59:08 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       X-Amz-Request-Id:
-      - tx000000000000000426f01-005847d838-899badb-uk-sal01
+      - tx00000000000000005c66a-00593fd38c-e1c7939-uk-sal01
       Strict-Transport-Security:
       - max-age=31536000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:00 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:08 GMT
 - request:
     method: get
-    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1481103720&Signature=74yP/oN90V28Ry0XzOCSDc0ZIIE=
+    uri: https://storage.datacentred.io/stronghold_usage/3a6a220de-9a92-4320-803a-5fa95492386?AWSAccessKeyId=I9860H3V0MMNO5B3FQSX&Expires=1497355448&Signature=42lbSs4Cf1TUTAy1/8bemmA4TCE=
     body:
       encoding: US-ASCII
       string: ''
@@ -312,11 +320,11 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Wed, 07 Dec 2016 09:36:56 GMT
+      - Tue, 13 Jun 2017 11:59:08 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       X-Amz-Request-Id:
-      - tx000000000000000426f5a-005847d838-8949e01-uk-sal01
+      - tx00000000000000005c6ad-00593fd38c-e6a31a3-uk-sal01
       Accept-Ranges:
       - bytes
       Content-Length:
@@ -327,7 +335,7 @@ http_interactions:
       - max-age=31536000
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><BucketName>stronghold_usage</BucketName><RequestId>tx000000000000000426f5a-005847d838-8949e01-uk-sal01</RequestId><HostId>8949e01-uk-sal01-uk</HostId></Error>
+      string: <?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchKey</Code><BucketName>stronghold_usage</BucketName><RequestId>tx00000000000000005c6ad-00593fd38c-e6a31a3-uk-sal01</RequestId><HostId>e6a31a3-uk-sal01-uk</HostId></Error>
     http_version: 
-  recorded_at: Wed, 07 Dec 2016 09:37:01 GMT
+  recorded_at: Tue, 13 Jun 2017 11:59:08 GMT
 recorded_with: VCR 2.9.3

--- a/test/unit/models/billing/usage/usage_sync_ceph_test.rb
+++ b/test/unit/models/billing/usage/usage_sync_ceph_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestUsageSyncCeph < CleanTest
   def setup
     @blob = {
-      complex: OpenStruct.new(foo: 'bar')
+      complex: {foo: 'bar'}
     }
     # This needs hardcoding for VCR
     @uuid = '3a6a220de-9a92-4320-803a-5fa95492386'
@@ -21,8 +21,8 @@ class TestUsageSyncCeph < CleanTest
       @usage = Billing::Usage.make!(object_uuid: @uuid, blob: @blob)
       object_uuid = @usage.object_uuid
 
-      assert_equal 'bar', @usage.blob[:complex].foo
-      assert_equal 'bar', manually_retrieve_object('stronghold_usage', object_uuid)[:complex].foo
+      assert_equal 'bar', @usage.blob[:complex][:foo]
+      assert_equal 'bar', manually_retrieve_object('stronghold_usage', object_uuid)[:complex][:foo]
 
       # Test update
       @usage.blob = {something: 'else'}
@@ -47,14 +47,15 @@ class TestUsageSyncCeph < CleanTest
       :access_key_id     => CEPH_ARGS[:ceph_token],
       :secret_access_key => CEPH_ARGS[:ceph_key]
     )
-    Marshal.load(
+    JSON.parse(
       open(
         AWS::S3::S3Object.url_for(
           object_uuid,
           bucket,
           authenticated: true
         )
-      )
+      ).read,
+      symbolize_names: true
     )
   end
 end


### PR DESCRIPTION
The format of the data document we use to describe data usage for an organization is now substantially different.

The reason for this is to reduce the amount of code in Harbour that has to adjust the data for the user's benefit - we want the cleanest format possible internally before we expose the data to the user. This will hopefully keep format changes to a minimum going forward and allow us to roll out small changes with API microversioning rather than big-bang style breaking changes.

Highlights:

* Volume usage is now calculated in line with instance usage. This means significantly less code as the volume states reflect their combined usage totals rather than some complex method that tries to wrangle everything together.
* The data is now stored completely in JSON on Ceph, rather than in a marshal-dump form containing real Ruby objects. This will take up a lot less space and be less error prone in future.
* The general format of the data is cleaner and tidier with more consistent features across different resource types. This includes a consistent format for usage and costing per resource.

The Billing::Usage objects on production will need rebuilding manually, and the volume states will need to be reindexed. I will be performing these changes during a period of scheduled downtime.