### PR TITLE
Sort invoices by cost.

### DIFF
--- a/app/models/billing/invoice.rb
+++ b/app/models/billing/invoice.rb
@@ -23,9 +23,9 @@ module Billing
 
     validates :organization, :year, :month, presence: true
 
-    scope :reverse_order,  -> { order('created_at DESC') }
-    scope :unfinalized,    -> { reverse_order.where(finalized: false) }
-    scope :finalized,      -> { reverse_order.where(finalized: true)  }
+    scope :cost_reverse_order,  -> { order('grand_total DESC') }
+    scope :unfinalized,    -> { cost_reverse_order.where(finalized: false) }
+    scope :finalized,      -> { cost_reverse_order.where(finalized: true)  }
     scope :self_service,   -> { joins(:organization).where('organizations.self_service = ?', true) }
     scope :manual_invoice, -> { joins(:organization).where('organizations.self_service = ?', false) }
 


### PR DESCRIPTION
[APP-526](https://datacentred.atlassian.net/browse/APP-526).

This changes will sort finalised and unfinalized invoices by their cost (grand total 💷 ), instead of their created date. 
![screen shot 2017-06-26 at 14 55 06](https://user-images.githubusercontent.com/12121779/27542557-7b8d4986-5a7f-11e7-87c7-07f566da1148.png)

