### PR TITLE
Loading overlay screen not working on Safari.

### DIFF
--- a/app/assets/javascripts/site_wide/support/dashboard.js
+++ b/app/assets/javascripts/site_wide/support/dashboard.js
@@ -66,7 +66,8 @@ $(document).ready(function() {
     });
   }
 
-  $('#select-organization').change(function() {
+  $('#select-organization').change(function(e) {
+    e.preventDefault();
     $('#loading-overlay').removeClass('hide');
     $(this).closest('form').submit();
   });


### PR DESCRIPTION
[APP-530](https://datacentred.atlassian.net/browse/APP-530)

When performing tasks that require more time than normal, a screen with a spinning cog will be shown, by removing the `hide` class from the element with `#loading-overlay` id.

This works fine on Chrome, Firefox, Opera and iOS, but it doesn't on Safari.