### PR TITLE
Allow users to get their DataCentred credentials.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: git@github.com:datacentred/harbour.git
-  revision: 12031d5cc5b62506b283dae5950b6fc3fa64eed7
+  revision: 00aab1665a399054857efe3c6c54437cfcdda647
   branch: master
   specs:
     harbour (0.1.0)

--- a/app/controllers/support/dashboard_controller.rb
+++ b/app/controllers/support/dashboard_controller.rb
@@ -20,7 +20,6 @@ module Support
     end
 
     def regenerate_datacentred_api_credentials
-      slow_404 unless current_user.staff?
       secret_key = current_user.refresh_datacentred_api_credentials!
       render json: {success: true, secret_key: secret_key}
     rescue StandardError => e

--- a/app/jobs/check_datacentred_api_access_job.rb
+++ b/app/jobs/check_datacentred_api_access_job.rb
@@ -1,0 +1,10 @@
+class CheckDataCentredApiAccessJob < ApplicationJob
+  queue_as :default
+
+  def perform(user, organization)
+    credential = ApiCredential.find_by(user: user, organization: organization)
+    return unless credential
+
+    credential.update_attributes enabled: User::Ability.new(user).can?(:read, :api)
+  end
+end

--- a/app/lib/permissions.rb
+++ b/app/lib/permissions.rb
@@ -17,6 +17,7 @@ class Permissions
         perms.merge!('usage.read'   => { :description => I18n.t(:can_usage_read),     :group => I18n.t(:cloud) })
         perms.merge!('cloud.read'   => { :description => I18n.t(:can_cloud_access),   :group => I18n.t(:cloud) })
         perms.merge!('storage.read' => { :description => I18n.t(:can_storage_access), :group => I18n.t(:cloud) })
+        perms.merge!('api.read'     => { :description => I18n.t(:can_api_access),     :group => I18n.t(:cloud) })
       end
 
       return perms

--- a/app/models/api_credential.rb
+++ b/app/models/api_credential.rb
@@ -7,6 +7,8 @@ class ApiCredential < ApplicationRecord
 
   after_create :generate_access_key
 
+  scope :enabled, -> { where(enabled: true) }
+
   def authenticate_and_authorize(password)
     authenticate(password) && User::Ability.new(user).can?(:read, :api)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,6 +229,10 @@ class User < ApplicationRecord
     CheckCephAccessJob.perform_later(self) if Rails.env.production?
   end
 
+  def check_datacentred_api_access
+    CheckDataCentredApiAccessJob.perform_later(self, current_organization) unless Rails.env.test?
+  end
+
   def remove_ceph_keys
     if Rails.env.production?
       begin

--- a/app/models/user/ability.rb
+++ b/app/models/user/ability.rb
@@ -6,33 +6,33 @@ class User::Ability
     alias_action :new, :create, :edit, :update, :destroy, :read, :index, :to => :modify
 
     # Instances
-    can :read, OpenStack::Instance   if user.has_permission?('instances.read')
+    can :read,   OpenStack::Instance if user.has_permission?('instances.read')
     can :modify, OpenStack::Instance if user.has_permission?('instances.modify')
 
     # Roles
-    can :read, Role       if user.has_permission?('roles.read')
-    can :read, User       if user.has_permission?('roles.read')
+    can :read,   Role     if user.has_permission?('roles.read')
+    can :read,   User     if user.has_permission?('roles.read')
     can :modify, Role     if user.has_permission?('roles.modify')
     can :modify, User     if user.has_permission?('roles.modify')
     can :modify, RoleUser if user.has_permission?('roles.modify')
     can :modify, Invite   if user.has_permission?('roles.modify')
 
     # Tickets
-    ticket_permissions          = ['tickets.modify', 'access_requests.raise_for_self', 'access_requests.raise_for_others']
-    user_has_ticket_permission  = -> (user) { ticket_permissions.any?{|p| user.has_permission?(p)} }
+    ticket_permissions         = ['tickets.modify', 'access_requests.raise_for_self', 'access_requests.raise_for_others']
+    user_has_ticket_permission = -> (user) { ticket_permissions.any?{|p| user.has_permission?(p)} }
 
-    can :modify, Ticket             if user_has_ticket_permission.call(user)
-    can :modify, TicketComment      if user_has_ticket_permission.call(user)
+    can :modify, Ticket        if user_has_ticket_permission.call(user)
+    can :modify, TicketComment if user_has_ticket_permission.call(user)
 
     # Access Requests
-    can :raise_for_self, Ticket     if user.has_permission?('access_requests.raise_for_self')
-    can :raise_for_others, Ticket   if user.has_permission?('access_requests.raise_for_others')
+    can :raise_for_self,   Ticket if user.has_permission?('access_requests.raise_for_self')
+    can :raise_for_others, Ticket if user.has_permission?('access_requests.raise_for_others')
 
     # Cloud
     can :read, :usage   if user.has_permission?('usage.read')
     can :read, :cloud   if user.has_permission?('cloud.read')
     can :read, :storage if user.has_permission?('storage.read')
-    can :read, :api     if user.power_user?
+    can :read, :api     if user.has_permission?('api.read')
 
     ## Power User can do everything
     can :modify, :all if user.power_user?

--- a/app/views/shared/_cloud_services.html.haml
+++ b/app/views/shared/_cloud_services.html.haml
@@ -34,7 +34,7 @@
             - if current_organization.storage? && can?(:read, :storage)
               %div.tab-pane{'role' => "tabpanel", 'class' => @openstack_active ? '' : 'active', 'id' => "ceph"}
                 = render partial: 'shared/ceph_details'
-            - if can?(:read, :api) && current_user.staff?
+            - if can?(:read, :api)
               %div.tab-pane{'role' => "tabpanel", 'class' => @openstack_active ? '' : 'active', 'id' => "datacentred-api"}
                 = render partial: 'shared/datacentred_api'
           

--- a/db/migrate/20170714141851_make_credentials_enablable.rb
+++ b/db/migrate/20170714141851_make_credentials_enablable.rb
@@ -1,0 +1,6 @@
+class MakeCredentialsEnablable < ActiveRecord::Migration[5.0]
+  def change
+    add_column :api_credentials, :enabled, :boolean, null: false, default: true
+    add_index  :api_credentials, :enabled, name: "index_api_credentials_on_enabled", where: "(enabled IS FALSE)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170705084827) do
+ActiveRecord::Schema.define(version: 20170714141851) do
 
   create_table "api_credentials", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
     t.string   "access_key"
     t.string   "password_digest"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
     t.integer  "organization_id"
+    t.boolean  "enabled",         default: true, null: false
+    t.index ["enabled"], name: "index_api_credentials_on_enabled", using: :btree
   end
 
   create_table "audits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
**DO NOT MERGE**

This change allows users to view/regenerate their API credentials, providing they have the right permission.