### PR TITLE
Make sure we lock out users via the API too.

### DIFF
--- a/app/jobs/check_data_centred_api_access_job.rb
+++ b/app/jobs/check_data_centred_api_access_job.rb
@@ -1,10 +1,10 @@
 class CheckDataCentredApiAccessJob < ApplicationJob
   queue_as :default
 
-  def perform(user, organization)
+  def perform(organization, user, state=nil)
     credential = ApiCredential.find_by(user: user, organization: organization)
     return unless credential
 
-    credential.update_attributes enabled: User::Ability.new(user).can?(:read, :api)
+    credential.update_attributes enabled: (state.nil? ? User::Ability.new(user).can?(:read, :api) : state)
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -5,7 +5,7 @@ class Role < ApplicationRecord
   has_and_belongs_to_many :users, -> { distinct }
   belongs_to :organization
   before_destroy :check_power, :check_users
-  after_commit :check_openstack_access, :check_ceph_access
+  after_commit :check_openstack_access, :check_ceph_access, :check_datacentred_api_access
   after_save :generate_uuid, :on => :create
 
   serialize :permissions
@@ -44,6 +44,10 @@ class Role < ApplicationRecord
   def check_ceph_access
     return unless Rails.env.production?
     users.each {|user| CheckCephAccessJob.perform_later(user)}
+  end
+
+  def check_datacentred_api_access
+    users.each {|user| CheckDataCentredApiAccessJob.perform_later(organization, user)}
   end
 
   def permissions_are_valid

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
   before_save :valid_email_address
   after_save :update_password
   after_commit :generate_ec2_credentials, on: :create
-  after_commit :check_openstack_access, :check_ceph_access, on: :create
+  after_commit :check_openstack_access, :check_ceph_access, :check_datacentred_api_access, on: :create
 
   after_create :set_local_password, :subscribe_to_status_io
   before_destroy :dont_delete_self, :remove_ceph_keys, :unsubscribe_from_status_io
@@ -230,7 +230,7 @@ class User < ApplicationRecord
   end
 
   def check_datacentred_api_access
-    CheckDataCentredApiAccessJob.perform_later(self, current_organization) unless Rails.env.test?
+    CheckDataCentredApiAccessJob.perform_later(current_organization, self) unless Rails.env.test?
   end
 
   def remove_ceph_keys


### PR DESCRIPTION
It's essential to make sure that enabling/disabling user access also applies to the API. There's no point freezing someone's account only for them to be able to happily do actions via the API instead of the UI.