### PR TITLE
Automatically run janitor after sanity check and fix where possible.

### DIFF
--- a/app/jobs/janitor_job.rb
+++ b/app/jobs/janitor_job.rb
@@ -1,0 +1,7 @@
+class JanitorJob < ApplicationJob
+  queue_as :slow
+
+  def perform(sanity_data)
+    Janitor.sweep(sanity_data, dry_run: true)
+  end
+end

--- a/app/jobs/usage_sanity_job.rb
+++ b/app/jobs/usage_sanity_job.rb
@@ -7,6 +7,7 @@ class UsageSanityJob < ApplicationJob
       Notifications.notify(:good, 'Sanity check passed.')
     else
       Sanity.notify!(check)
+      JanitorJob.perform_later(check)
     end
   end
 end

--- a/app/lib/janitor.rb
+++ b/app/lib/janitor.rb
@@ -1,0 +1,44 @@
+module Janitor
+  def self.sweep(sanity_data, dry_run: false)
+    sweep_instances(sanity_data[:missing_instances].keys, dry_run: dry_run)
+  end
+
+  private
+
+  def self.sweep_instances(instance_ids, dry_run: false)
+    instance_ids.each do |id|
+      instance = Billing::Instance.find_by_instance_id(id)
+      if absent_from_live_resources?('servers', id)
+        if instance.total_billable_seconds == 0
+          unless dry_run
+            instance.instance_states.delete_all
+            instance.delete
+          end
+          logger.info "Instance #{id} is absent from hypervisor and has no billable time. Deleted."
+        else
+          unless dry_run
+            instance.instance_states.create! recorded_at: Time.now,
+                                             state:       'deleted',
+                                             event_name:  'compute.instance.detected_absence',
+                                             message_id:  SecureRandom.hex,
+                                             sync_id:     Billing::Sync.last.id
+            instance.reindex_states
+          end
+          logger.info "Instance #{id} is missing delete event. Automatically added one."
+        end
+      end
+    end
+  end
+
+  def self.absent_from_live_resources?(kind, uuid)
+    LiveCloudResources.send(kind).map{|x| x['id']}.exclude?(uuid)
+  end
+
+  def self.logger
+    if Rails.env.production?
+      ::Logger.new("/var/log/rails/stronghold/janitor.log")
+    else
+      Rails.logger
+    end
+  end
+end

--- a/app/models/billing/instance.rb
+++ b/app/models/billing/instance.rb
@@ -34,6 +34,10 @@ module Billing
       instance_states&.last&.update_column(:next_state_id, nil)
     end
 
+    def total_billable_seconds
+      instance_states.select{|s| s.billable?}.sum{|s| s.total_seconds }
+    end
+
     def terminated_at
       terminated_at = read_attribute(:terminated_at)
       return terminated_at if terminated_at

--- a/app/models/billing/instance_state.rb
+++ b/app/models/billing/instance_state.rb
@@ -40,6 +40,10 @@ module Billing
       to - from
     end
 
+    def total_seconds
+      ((last_state? ? Time.now : next_state.recorded_at) - recorded_at).round
+    end
+
     def to_hash(from=nil, to=nil)
       {
         billable:    billable?,

--- a/test/unit/lib/janitor_test.rb
+++ b/test/unit/lib/janitor_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class TestJanitor < CleanTest
+
+  def setup
+    @instance = Billing::Instance.create!({
+      instance_id: 'ff90714a-6b5e-45e4-9253-c952b63bb3d6',
+      name: 'foo',
+    })
+    @live_servers = [
+      {'id' => 'ff90714a-6b5e-45e4-9253-c952b63bb3d6'}
+    ]
+    t = Time.now - 1.month
+    Billing::Sync.create! completed_at: t,
+                          started_at:   t,
+                          period_from:  t,
+                          period_to:    t
+  end
+
+  def test_if_instance_still_exists_do_nothing
+    LiveCloudResources.stub(:send, @live_servers, [:servers]) do
+      Janitor.sweep(test_data)
+    end
+    assert_equal 1, Billing::Instance.all.count
+  end
+
+  def test_instance_has_zero_events_and_doesnt_exist_anymore
+    LiveCloudResources.stub(:servers, []) do
+      Janitor.sweep(test_data)
+    end
+    assert_equal 0, Billing::Instance.all.count
+  end
+
+  def test_instance_unchanged_if_dry_run
+    LiveCloudResources.stub(:servers, []) do
+      Janitor.sweep(test_data, dry_run: true)
+    end
+    assert_equal 1, Billing::Instance.all.count
+  end
+
+  def test_instance_with_events_gets_a_deleted_event_added
+    t = Time.now - 2.weeks
+    @instance.instance_states.create! recorded_at: t,
+                                      state:       'building',
+                                      event_name:  'compute.instance.create.start'
+    @instance.instance_states.create! recorded_at: (t + 5.seconds),
+                                      state:       'active',
+                                      event_name:  'compute.instance.create.end'
+    @instance.reindex_states
+
+    @billable_seconds = @instance.total_billable_seconds
+
+    LiveCloudResources.stub(:servers, []) do
+      Janitor.sweep(test_data)
+    end
+
+    Timecop.freeze(Time.now + 1.year) do
+      assert_equal @billable_seconds, @instance.reload.total_billable_seconds
+    end
+
+    assert_equal 3, @instance.instance_states.count  
+  end
+
+  def test_instance_with_events_untouched_after_dry_run
+    t = Time.now - 2.weeks
+    @instance.instance_states.create! recorded_at: t,
+                                      state:       'building',
+                                      event_name:  'compute.instance.create.start'
+    @instance.reindex_states
+
+    LiveCloudResources.stub(:servers, []) do
+      Janitor.sweep(test_data, dry_run: true)
+    end
+
+    assert_equal 1, @instance.instance_states.count
+  end
+
+  private
+
+  def test_data
+    {
+      :missing_instances => {
+        "ff90714a-6b5e-45e4-9253-c952b63bb3d6" => {
+          :name       => "testing_stress_arctic_1",
+          :project_id => "d24c8005301644589999103298c62048"
+        }
+      },
+      :missing_volumes => {},
+      :missing_images  => {},
+      :new_instances   => {},
+      :sane            => false
+    }
+  end
+end


### PR DESCRIPTION
`Janitor` is responsible for automatically fixing sanity check failures where possible.

The reasons for failures are many (API issues, bugs in Nova etc) but if an instance is missing from the hypervisor and has zero/some events then we can make a best guess as to the best course of action.

This commit doesn't seek to tackle missing volumes, images etc. We'll add to the rules/tests slowly and tease out the best behaviours.

Initially we'll run with `dry_run` and check the log output. We'll make it live when we're confident it works.