### PR TITLE
Check the raw ceilometer history for the instance.

### DIFF
--- a/app/models/billing/instance.rb
+++ b/app/models/billing/instance.rb
@@ -38,6 +38,15 @@ module Billing
       instance_states.select{|s| s.billable?}.sum{|s| s.total_seconds }
     end
 
+    def raw_history
+      options = [{'field' => 'resource_id', 'type' => 'string', 'op' => 'eq', 'value' => instance_id}]
+      @raw_history ||= OpenStackConnection.metering.get_samples('instance', options).body
+    end
+
+    def raw_billable_states
+      raw_history.map{|h| h['resource_metadata']['state']}.select{|s| InstanceState.billable?(s)}
+    end
+
     def terminated_at
       terminated_at = read_attribute(:terminated_at)
       return terminated_at if terminated_at

--- a/app/models/billing/instance_state.rb
+++ b/app/models/billing/instance_state.rb
@@ -31,6 +31,10 @@ module Billing
     def billable?
       delete_states = billing_instance.instance_states.where(state: 'deleted')
       return false if delete_states.any?{|s| s.recorded_at < recorded_at}
+      InstanceState.billable?(state)
+    end
+
+    def self.billable?(state)
       !["error","building", "stopped", "suspended", "shutoff", "deleted", "resized"].include?(state.downcase)
     end
 


### PR DESCRIPTION
This will help us detect discrepancies between Stronghold's recorded usage data and the data we have in ceilometer.