### PR TITLE
Additional fix to CSV Usage Report Error.

### DIFF
--- a/app/helpers/usage_helper.rb
+++ b/app/helpers/usage_helper.rb
@@ -52,13 +52,17 @@ module UsageHelper
     @flavors ||= Hash[Billing::InstanceFlavor.all.map{|f| [f.flavor_id, f.name]}]
   end
 
+  def instance_flavor_name(instance)
+    [instance[:current_flavor][:name], instance[:tags].select{|t| t == "windows"}.map{|t| " (#{t.capitalize})"}].join
+  end
+
   def usage_data_as_csv(data)
     CSV.generate do |csv|
       csv << ["Project", "Type", "Sub-Type", "ID", "Name", "Amount", "Unit", "Cost (£)"]
       data[:projects].each do |project|
         project[:usage][:instances].each do |instance|
           instance[:usage].each do |usage|
-            csv << [project[:name], "Instance", nil, usage[:meta][:flavor][:id], usage[:meta][:name], usage[:value], 'hours', usage[:cost][:value]]
+            csv << [project[:name], "Instance", instance_flavor_name(instance) , usage[:meta][:flavor][:id], usage[:meta][:name], usage[:value], 'hours', usage[:cost][:value]]
           end
         end
         project[:usage][:volumes].each do |volume|

--- a/test/files/usage.json
+++ b/test/files/usage.json
@@ -93,7 +93,7 @@
             "latest_state": "active",
             "name": "awesome",
             "tags": [
-
+              "windows", "walls", "doors"
             ],
             "terminated_at": null,
             "usage": [

--- a/test/files/usage_report.csv
+++ b/test/files/usage_report.csv
@@ -1,6 +1,6 @@
 Project,Type,Sub-Type,ID,Name,Amount,Unit,Cost (£)
-wyld_stallyns,Instance,,b671216b-1c68-4765-b752-0e8e6b6d015f,,586,hours,20.39
-wyld_stallyns,Instance,,9cf6e43b-e191-47ca-8665-f8592e2d6227,,586,hours,81.51
+wyld_stallyns,Instance,dc1.1x2 (Windows),b671216b-1c68-4765-b752-0e8e6b6d015f,,586,hours,20.39
+wyld_stallyns,Instance,dc1.4x8,9cf6e43b-e191-47ca-8665-f8592e2d6227,,586,hours,81.51
 wyld_stallyns,Volume,Ceph SSD,7587d8b3-ddff-4ea3-b562-cf0fe2fe5864,excellent,17.16,TB/h,7.05
 wyld_stallyns,Image,,72d6058a-ce79-4556-8adb-b669cadeea07,bodacious,,TB/h,0.01
 wyld_stallyns,Image,,f61ea97c-dd83-4a5b-90d7-a1f151d7120e,non-heinous,,TB/h,0.02

--- a/test/unit/helpers/usage_helper_test.rb
+++ b/test/unit/helpers/usage_helper_test.rb
@@ -70,4 +70,11 @@ class UsageHelperTest < CleanTest
     assert_equal(expected_csv, generated_csv)
   end
 
+  def test_instance_flavor_name
+    instance = {current_flavor: {name: "Foo"}, tags: []}
+    assert_equal "Foo", @model.instance_flavor_name(instance)
+    instance = {current_flavor: {name: "Bar All The"}, tags: ["doors", "walls", "windows"]}
+    assert_equal "Bar All The (Windows)", @model.instance_flavor_name(instance)
+  end
+
 end


### PR DESCRIPTION
There was some info missing in the previous fix (PR#374), the column Sub-Type for Instances need to be filled with the flavour name and a tag indicating if it's Windows. 