### PR TITLE
Use Excon instrumentation to log calls.

### DIFF
--- a/config/excon.yml
+++ b/config/excon.yml
@@ -1,0 +1,18 @@
+development:
+  debug: true
+
+test:
+  debug: false
+
+staging:
+  debug: true
+
+acceptance:
+  debug: false
+
+vagrant:
+  debug: false
+
+production:
+  debug: true
+  log: /var/log/rails/stronghold/openstack_requests.log

--- a/config/initializers/excon.rb
+++ b/config/initializers/excon.rb
@@ -1,0 +1,44 @@
+require 'fog/openstack'
+
+module ExconConnection
+  def self.config_load
+    YAML.load_file("#{Rails.root}/config/excon.yml")[Rails.env].symbolize_keys!
+  end
+  def self.configuration
+    @@config_cache ||= config_load
+  end
+end
+
+ENV["EXCON_DEBUG"] = "1" if ExconConnection.configuration[:debug]
+
+module Excon
+  class StandardInstrumentor
+    def self.format_log(params)
+      if params.include?(:status)
+        request_id = params[:headers].slice("X-Compute-Request-Id", "x-openstack-request-id", "X-Openstack-Request-Id").values.uniq.join(", ")
+        ["[OpenStack] HTTP #{params[:status]} #{params[:reason_phrase]}", request_id].compact.join(" - ")
+      else
+        ["[OpenStack] #{params[:method]} #{params[:scheme]}://#{params[:host]}:#{params[:port]}#{[params[:path],(params[:query]&.to_query)].compact.join('?')}", params[:body]].compact.join(" => ")
+      end
+    end
+
+    def self.instrument(name, params = {}, &block)
+      params = params.dup
+      logger.info(format_log(params)) unless params[:path] == "/v3/auth/tokens"
+      yield if block_given?
+    end
+
+    def self.logger
+      if Rails.env.production?
+        ::Logger.new(ExconConnection.configuration[:log])
+      else
+        Rails.logger
+      end
+    end
+  end
+end
+
+Excon.defaults[:connect_timeout] = 10
+Excon.defaults[:write_timeout] = 180
+Excon.defaults[:read_timeout] = 180
+

--- a/config/initializers/openstack.rb
+++ b/config/initializers/openstack.rb
@@ -1,8 +1,5 @@
 require 'fog/openstack'
-
-Excon.defaults[:connect_timeout] = 10
-Excon.defaults[:write_timeout] = 180
-Excon.defaults[:read_timeout] = 180
+require_relative "./excon"
 
 module OpenStackConnection
   @@service_provider = 'datacentred'


### PR DESCRIPTION
We need to record all OpenStack calls (and request ids) in a log.

Production env outputs to a dedicated log file. All other environments output to the existing Rails logger.

```
I, [2017-08-09T11:57:48.493971 #10688]  INFO -- : [OpenStack] PATCH https://compute.datacentred.io:35357/v3/projects/4fccc2079960432581ab884812e8a625 => {"project":{"name":"foobarbaz","description":"Customer: DataCentred, Project: foobarbaz"}}
I, [2017-08-09T11:57:48.576060 #10688]  INFO -- : [OpenStack] HTTP 200 OK - req-92b9ba69-1697-47e2-a78b-3216ed3fbcb2
I, [2017-08-09T11:57:48.844238 #10688]  INFO -- : [OpenStack] GET https://compute.datacentred.io:35357/v3/roles?
I, [2017-08-09T11:57:48.918580 #10688]  INFO -- : [OpenStack] HTTP 200 OK - req-7b442652-fd29-431b-9fd6-c63f944df82e
I, [2017-08-09T11:57:49.670157 #10688]  INFO -- : [OpenStack] GET https://compute.datacentred.io:35357/v3/projects?
I, [2017-08-09T11:57:50.066906 #10688]  INFO -- : [OpenStack] HTTP 200 OK - req-8ea7a8de-d4bf-4cd4-bd1e-75d490e994a4
```